### PR TITLE
add mandatory type for new tekton version

### DIFF
--- a/backend-k8s/steward-system/300_clusterTask_steward-jenkinsfile-runner.yaml
+++ b/backend-k8s/steward-system/300_clusterTask_steward-jenkinsfile-runner.yaml
@@ -6,52 +6,64 @@ spec:
   inputs:
     params:
     - name: PIPELINE_PARAMS_JSON
+      type: string
       description: >
         Parameters to pass to the pipeline, as JSON string.
     - name: PIPELINE_GIT_URL
+      type: string
       description: >
         The URL of the Git repository containing the pipeline definition.
     - name: PIPELINE_GIT_REVISION
+      type: string
       description: >
         The revision of the pipeline Git repository to used, e.g. 'master'.
     - name: PIPELINE_FILE
+      type: string
       description: >
         The relative pathname of the pipeline definition file, typically 'Jenkinsfile'.
     - name: PIPELINE_LOG_ELASTICSEARCH_INDEX_URL
+      type: string
       description: >
         The URL of the Elasticsearch index to send logs to.
         If null or empty, logging to Elasticsearch is disabled.
         # Example: http://elasticsearch-master.elasticsearch.svc.cluster.local:9200/jenkins-logs/_doc
       default: ""
     - name: PIPELINE_LOG_ELASTICSEARCH_AUTH_SECRET
+      type: string
       description: >
         The name of the secret of type basic-auth to use to authenticate to Elasticsearch.
         If null or empty, no authentication takes place.
       default: ""
     - name: PIPELINE_LOG_ELASTICSEARCH_TRUSTEDCERTS_SECRET
+      type: string
       description: >
         The name of the secret providing the trusted certificates bundle used for TLS server verification when connecting to Elasticsearch.
         If null or empty, the default trusted certificates are used.
       default: ""
     - name: PIPELINE_LOG_ELASTICSEARCH_RUN_ID_JSON
+      type: string
       description: >
         The value for the 'runId' field of log events, as JSON string.
         Must be specified if logging to Elasticsearch is enabled.
       default: ""
     - name: RUN_NAMESPACE
+      type: string
       description: >
         The namespace of this pipeline run.
     - name: JOB_NAME
+      type: string
       description: >
         The name of the job this pipeline run belongs to. It is used as the name of the Jenkins job and therefore must be a valid Jenkins job name.
         If null or empty, `job` will be used.
       default: ""
     - name: RUN_NUMBER
+      type: string
       description: >
         The sequence number of the pipeline run, which translates into the build number of the Jenkins job.
         If null or empty, `1` is used.
       default: "1"
     - name: RUN_CAUSE
+      type: string
       description: >
         A textual description of the cause of this pipeline run. Will be set as cause of the Jenkins job.
         If null or empty, no cause information will be available.


### PR DESCRIPTION
Found the follwing message in the tekton taskrun.

message: 'invalid input params: param types don''t match the user-specified
        type: [RUN_NAMESPACE PIPELINE_GIT_URL PIPELINE_GIT_REVISION PIPELINE_FILE
        PIPELINE_PARAMS_JSON PIPELINE_LOG_ELASTICSEARCH_INDEX_URL]'
