### PR TITLE
runctl: run JFR container with service account 'default'

### DIFF
--- a/pkg/k8s/serviceAccountManager.go
+++ b/pkg/k8s/serviceAccountManager.go
@@ -47,22 +47,19 @@ func NewServiceAccountManager(factory ClientFactory, namespace string) ServiceAc
 //   imagePullSecretNames		(optional) a list of image pull secrets to attach to this service account (e.g. for pulling the Jenkinsfile Runner image)
 func (c *serviceAccountManager) CreateServiceAccount(name string, pipelineCloneSecretName string, imagePullSecretNames []string) (*ServiceAccountWrap, error) {
 	serviceAccount := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if pipelineCloneSecretName != "" {
-		secretList := make([]v1.ObjectReference, 1)
-		secretList[0] = v1.ObjectReference{Name: pipelineCloneSecretName}
-		serviceAccount.Secrets = secretList
-	}
-	refList := make([]v1.LocalObjectReference, len(imagePullSecretNames))
-	for index, imagePullSecretName := range imagePullSecretNames {
-		refList[index] = v1.LocalObjectReference{Name: imagePullSecretName}
-		serviceAccount.ImagePullSecrets = refList
+	serviceAccountWrap := &ServiceAccountWrap{
+		factory: c.factory,
+		cache:   serviceAccount,
 	}
 
-	account, err := c.client.Create(serviceAccount)
-	return &ServiceAccountWrap{
-		factory: c.factory,
-		cache:   account,
-	}, err
+	if pipelineCloneSecretName != "" {
+		serviceAccountWrap.AttachSecrets(pipelineCloneSecretName)
+	}
+	serviceAccountWrap.AttachImagePullSecrets(imagePullSecretNames...)
+
+	serviceAccount, err := c.client.Create(serviceAccount)
+	serviceAccountWrap.cache = serviceAccount
+	return serviceAccountWrap, err
 }
 
 // GetServiceAccount gets a ServiceAccount from the cluster
@@ -76,6 +73,88 @@ func (c *serviceAccountManager) GetServiceAccount(name string) (serviceAccount *
 		cache:   account,
 	}
 	return
+}
+
+// AttachSecrets attaches a number of secrets to the service account.
+// It does NOT create or update the resource via the underlying client.
+func (a *ServiceAccountWrap) AttachSecrets(secretNames ...string) {
+	if len(secretNames) == 0 {
+		return
+	}
+
+	secretRefs := a.cache.Secrets
+
+	haveSecretAlready := func(name string) bool {
+		for _, secretRef := range secretRefs {
+			if secretRef.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	changed := false
+	for _, secretName := range secretNames {
+		if secretName == "" {
+			continue
+		}
+		if !haveSecretAlready(secretName) {
+			secretRef := v1.ObjectReference{Name: secretName}
+			secretRefs = append(secretRefs, secretRef)
+			changed = true
+		}
+	}
+
+	if changed {
+		a.cache.Secrets = secretRefs
+	}
+}
+
+// AttachImagePullSecrets attaches a number of secrets to the service account.
+// It does NOT create or update the resource via the underlying client.
+func (a *ServiceAccountWrap) AttachImagePullSecrets(secretNames ...string) {
+	if len(secretNames) == 0 {
+		return
+	}
+
+	secretRefs := a.cache.ImagePullSecrets
+
+	haveSecretAlready := func(name string) bool {
+		for _, secretRef := range secretRefs {
+			if secretRef.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	changed := false
+	for _, secretName := range secretNames {
+		if secretName == "" {
+			continue
+		}
+		if !haveSecretAlready(secretName) {
+			secretRef := v1.LocalObjectReference{Name: secretName}
+			secretRefs = append(secretRefs, secretRef)
+			changed = true
+		}
+	}
+
+	if changed {
+		a.cache.ImagePullSecrets = secretRefs
+	}
+}
+
+// Update performs an update of the service account resource object
+// via the underlying client.
+func (a *ServiceAccountWrap) Update() error {
+	client := a.factory.CoreV1().ServiceAccounts(a.cache.GetNamespace())
+	updatedObj, err := client.Update(a.cache)
+	if err != nil {
+		return err
+	}
+	a.cache = updatedObj
+	return nil
 }
 
 // AddRoleBinding creates a role binding in the targetNamespace connecting the service account with the specified cluster role


### PR DESCRIPTION
Currently a service account `run-bot` is used for the Jenkinsfile Runner
pod, while the `default` service account of the run namespace has no
permissions.

Pipeline implementations might need to start additional pods that should
have the same cluster API access as the JFR pod. To do so, they must
specify `run-bot` as the pod's `spec.serviceAccountName`. Omitting the
field results in running the additional pod as the `default` service
account, which has no cluster API permissions. This is considered as a
common mistake and should be avoided.

If we use the `default` service account instead of `run-bot` (having the
same permissions assigned as `run-bot` had; run JFR pod as `default`
service account), pipeline implementations don't have to deal with the
service account name when starting additional pods.