### PR TITLE
improve state

### DIFF
--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -68,10 +68,10 @@ type Elasticsearch struct {
 type PipelineStatus struct {
 	// StartedAt is the time the pipeline run has been started.
 	// +optional
-	StartedAt    *metav1.Time           `json:"startedAt,omitempty"`
+	StartedAt *metav1.Time `json:"startedAt,omitempty"`
 	// FinishedAt is the time the pipeline run has been finished.
 	// +optional
-	FinishedAt   *metav1.Time           `json:"finishedAt"`
+	FinishedAt   *metav1.Time          `json:"finishedAt"`
 	State        State                 `json:"state"`
 	StateDetails StateItem             `json:"stateDetails"`
 	StateHistory []StateItem           `json:"stateHistory"`
@@ -97,8 +97,8 @@ type State string
 const (
 	// StateUndefined - the state was not yet set
 	StateUndefined State = ""
-	// StatePickup - pipeline run is first checked by the controller
-	StatePickup State = "pickup"
+	// StateNew - pipeline run is first checked by the controller
+	StateNew State = "new"
 	// StatePreparing - the namespace for the execution is prepared
 	StatePreparing State = "preparing"
 	// StateWaiting - the pipeline run is waiting to be processed

--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -66,8 +66,12 @@ type Elasticsearch struct {
 
 // PipelineStatus represents the status of the pipeline
 type PipelineStatus struct {
-	StartedAt    metav1.Time           `json:"startedAt"`
-	FinishedAt   metav1.Time           `json:"finishedAt"`
+	// StartedAt is the time the pipeline run has been started.
+	// +optional
+	StartedAt    *metav1.Time           `json:"startedAt,omitempty"`
+	// FinishedAt is the time the pipeline run has been finished.
+	// +optional
+	FinishedAt   *metav1.Time           `json:"finishedAt"`
 	State        State                 `json:"state"`
 	StateDetails StateItem             `json:"stateDetails"`
 	StateHistory []StateItem           `json:"stateHistory"`

--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -66,6 +66,8 @@ type Elasticsearch struct {
 
 // PipelineStatus represents the status of the pipeline
 type PipelineStatus struct {
+	StartedAt    metav1.Time           `json:"startedAt"`
+	FinishedAt   metav1.Time           `json:"finishedAt"`
 	State        State                 `json:"state"`
 	StateDetails StateItem             `json:"stateDetails"`
 	StateHistory []StateItem           `json:"stateHistory"`
@@ -91,6 +93,8 @@ type State string
 const (
 	// StateUndefined - the state was not yet set
 	StateUndefined State = ""
+	// StatePickup - pipeline run is first checked by the controller
+	StatePickup State = "pickup"
 	// StatePreparing - the namespace for the execution is prepared
 	StatePreparing State = "preparing"
 	// StateWaiting - the pipeline run is waiting to be processed

--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -71,7 +71,7 @@ type PipelineStatus struct {
 	StartedAt *metav1.Time `json:"startedAt,omitempty"`
 	// FinishedAt is the time the pipeline run has been finished.
 	// +optional
-	FinishedAt   *metav1.Time          `json:"finishedAt"`
+	FinishedAt   *metav1.Time          `json:"finishedAt,omitempty"`
 	State        State                 `json:"state"`
 	StateDetails StateItem             `json:"stateDetails"`
 	StateHistory []StateItem           `json:"stateHistory"`

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -159,7 +159,7 @@ func (r *pipelineRun) UpdateState(state api.State) (*api.StateItem, error) {
 }
 
 // FinishState set end time stamp of the current (defined) state and add it to the history
-// if no current state is defined a new pickup state (A) with cretiontime of the pipelinerun as start time is created.
+// If no current state is defined a new pickup state (A) with creation time of the PipelineRun as start time is created.
 // Returns the state details
 func (r *pipelineRun) FinishState() (*api.StateItem, error) {
 	state := r.cached.Status.StateDetails

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -101,10 +101,11 @@ func Test_pipelineRun_UpdateState_AfterFirstCall(t *testing.T) {
 	// VERIFY
 	assert.Equal(t, api.StatePreparing, examinee.GetStatus().State)
 	assert.Equal(t, 1, len(examinee.GetStatus().StateHistory))
-	assert.Equal(t, api.StatePickup, examinee.GetStatus().StateHistory[0].State)
+	assert.Equal(t, api.StateNew, examinee.GetStatus().StateHistory[0].State)
 	assert.Equal(t, creationTimestamp, examinee.GetStatus().StateHistory[0].StartedAt)
-	assert.Assert(t, !examinee.GetStatus().StartedAt.IsZero())
-	assert.Equal(t, examinee.GetStatus().StartedAt, examinee.GetStatus().StateHistory[0].FinishedAt)
+	startedAt := examinee.GetStatus().StartedAt
+	assert.Assert(t, !startedAt.IsZero())
+	assert.Equal(t, *startedAt, examinee.GetStatus().StateHistory[0].FinishedAt)
 }
 
 func Test_pipelineRun_UpdateState_AfterSecondCall(t *testing.T) {
@@ -125,7 +126,7 @@ func Test_pipelineRun_UpdateState_AfterSecondCall(t *testing.T) {
 	// VERIFY
 	status := examinee.GetStatus()
 	assert.Equal(t, 2, len(status.StateHistory))
-	assert.Equal(t, api.StatePickup, examinee.GetStatus().StateHistory[0].State)
+	assert.Equal(t, api.StateNew, examinee.GetStatus().StateHistory[0].State)
 	assert.Equal(t, api.StatePreparing, status.StateHistory[1].State)
 
 	start := status.StateHistory[1].StartedAt

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -63,7 +63,7 @@ func Test_Controller_Success(t *testing.T) {
 
 	assert.Assert(t, !strings.Contains(status.Message, "ERROR"), status.Message)
 	assert.Equal(t, api.StateWaiting, status.State)
-	assert.Equal(t, 1, len(status.StateHistory))
+	assert.Equal(t, 2, len(status.StateHistory))
 }
 
 func Test_Controller_Running(t *testing.T) {


### PR DESCRIPTION
introduce fields
- startedAt for timestamp when pipeline run is first touched by the controller
- finishedAt for timestamp when pipeline run result is available

introduce state pickup as first element in the history recording the time
from pipeline run creation until first touch by the controller