### PR TITLE
handle pipeline run details as optional

### DIFF
--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -147,7 +147,7 @@ type PipelineRunDetails struct {
 	// JobName is the name of the job which is instantiated by the run.
 	JobName string `json:"jobName"`
 	// SequenceNumber is a sequential number of the run
-	SequenceNumber int `json:"sequenceNumber"`
+	SequenceNumber int32 `json:"sequenceNumber"`
 	// Cause is the cause which triggered the run, e.g. a SCM change, an user action or a timer.
 	Cause string `json:"cause"`
 }

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -252,12 +252,16 @@ func (c *runManager) addTektonTaskRunParamsForRunDetails(
 	spec := pipelineRun.GetSpec()
 	details := spec.RunDetails
 	if details != nil {
-		params := []tekton.Param{
-			tektonStringParam("JOB_NAME", details.JobName),
-			tektonStringParam("RUN_NUMBER", fmt.Sprintf("%d", details.SequenceNumber)),
-			tektonStringParam("RUN_CAUSE", details.Cause),
+		params := []tekton.Param{}
+		if details.JobName != "" {
+			params = append(params, tektonStringParam("JOB_NAME", details.JobName))
 		}
-
+		if details.SequenceNumber > 0 {
+			params = append(params, tektonStringParam("RUN_NUMBER", fmt.Sprintf("%d", details.SequenceNumber)))
+		}
+		if details.Cause != "" {
+			params = append(params, tektonStringParam("RUN_CAUSE", details.Cause))
+		}
 		tektonTaskRun.Spec.Inputs.Params = append(tektonTaskRun.Spec.Inputs.Params, params...)
 	}
 }

--- a/test/builder/pipelineRun.go
+++ b/test/builder/pipelineRun.go
@@ -116,7 +116,7 @@ func ImagePullSecret(name string) PipelineRunSpecOp {
 }
 
 // RunDetails creates a PipelineRunSpecOp which adds RunDetails
-func RunDetails(jobName, cause string, sequenceNumber int) PipelineRunSpecOp {
+func RunDetails(jobName, cause string, sequenceNumber int32) PipelineRunSpecOp {
 	return func(spec api.PipelineSpec) api.PipelineSpec {
 		spec.RunDetails = &api.PipelineRunDetails{
 			JobName:        jobName,


### PR DESCRIPTION
The run controller handles all fields of PipelineRunDetails as if they
are set, although all fields are optional and should not be passed as
Tekton TaskRun parameters if not set. Check for empty/unset values and
pass them to the Tekton TaskRun only if set.

Defining `sequenceNumber` as `int` is not appropriate for an API,
because it can be either 32-bit or 64-bit depending on the compilation
target architecture. For an API the size should be fixed. Use `int32`
instead.