### PR TITLE
simplify secret transformer functions

### DIFF
--- a/pkg/k8s/secrets/mocks/mocks.go
+++ b/pkg/k8s/secrets/mocks/mocks.go
@@ -57,7 +57,7 @@ func (m *MockSecretHelper) EXPECT() *MockSecretHelperMockRecorder {
 }
 
 // CopySecrets mocks base method
-func (m *MockSecretHelper) CopySecrets(arg0 []string, arg1 func(*v1.Secret) bool, arg2 ...func(*v1.Secret) *v1.Secret) ([]string, error) {
+func (m *MockSecretHelper) CopySecrets(arg0 []string, arg1 func(*v1.Secret) bool, arg2 ...func(*v1.Secret)) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {

--- a/pkg/k8s/secrets/secretUtils.go
+++ b/pkg/k8s/secrets/secretUtils.go
@@ -55,7 +55,7 @@ func (h *secretHelper) CopySecrets(secretNames []string, filter SecretFilter, tr
 			continue
 		}
 		for _, transformer := range transformers {
-			secret = transformer(secret)
+			transformer(secret)
 		}
 		storedSecret, err := h.CreateSecret(secret)
 		if err != nil {

--- a/pkg/k8s/secrets/transformers.go
+++ b/pkg/k8s/secrets/transformers.go
@@ -7,43 +7,36 @@ import (
 	"strings"
 )
 
-// SecretTransformer is a type for secret transformers
-// the function MUST NOT modify the original secret but
-// return a copy of the given one even if no modification took place
-type SecretTransformer = func(*v1.Secret) *v1.Secret
+// SecretTransformer is a function that modifies the given secret.
+type SecretTransformer = func(*v1.Secret)
 
-// UniqueNameTransformer returns a transforming function from secret to secret
-// the resulting secret has generateName set to the original name plus '-' as separator
-// and name is unset
+// UniqueNameTransformer returns a secret transformer function that sets
+// `metadata.generateName` to the original `metadata.name` with '-' appended as
+// separator and removes `metadata.name`.
 func UniqueNameTransformer() SecretTransformer {
-	return func(secret *v1.Secret) *v1.Secret {
-		secret = secret.DeepCopy()
+	return func(secret *v1.Secret) {
 		secret.SetGenerateName(fmt.Sprintf("%s-", secret.GetName()))
 		secret.SetName("")
-		return secret
 	}
 }
 
-// SetAnnotationTransformer returns a transforming function from secret to secret
-// in the result secret the annotation with key 'key' is set to the value 'value'.
+// SetAnnotationTransformer returns a secret transformer function that sets the
+// annotation with the given key to the given value.
 func SetAnnotationTransformer(key string, value string) SecretTransformer {
-	return func(secret *v1.Secret) *v1.Secret {
-		secret = secret.DeepCopy()
+	return func(secret *v1.Secret) {
 		annotations := secret.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
 		annotations[key] = value
 		secret.SetAnnotations(annotations)
-		return secret
 	}
 }
 
-// StripAnnotationsTransformer returns a transforming function from secret to secret
-// in the result secret all annotations with prefix 'keyPrefix' are removed.
+// StripAnnotationsTransformer returns a secret transformer function that
+// removes all annotations where the key starts with the given 'keyPrefix'.
 func StripAnnotationsTransformer(keyPrefix string) SecretTransformer {
-	return func(secret *v1.Secret) *v1.Secret {
-		secret = secret.DeepCopy()
+	return func(secret *v1.Secret) {
 		annotations := secret.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)
@@ -54,30 +47,26 @@ func StripAnnotationsTransformer(keyPrefix string) SecretTransformer {
 			}
 		}
 		secret.SetAnnotations(annotations)
-		return secret
 	}
 }
 
-// SetLabelTransformer returns a transforming function from secret to secret
-// in the result secret the label with key 'key' is set to the value 'value'.
+// SetLabelTransformer returns a secret transformer function that sets the
+// label with the given key to the given value.
 func SetLabelTransformer(key string, value string) SecretTransformer {
-	return func(secret *v1.Secret) *v1.Secret {
-		secret = secret.DeepCopy()
+	return func(secret *v1.Secret) {
 		labels := secret.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
 		labels[key] = value
 		secret.SetLabels(labels)
-		return secret
 	}
 }
 
-// StripLabelsTransformer returns a transforming function from secret to secret
-// in the result secret all labels with prefix 'keyPrefix' are removed.
+// StripLabelsTransformer returns a secret transformer function that
+// removes all labels where the key starts with the given 'keyPrefix'.
 func StripLabelsTransformer(keyPrefix string) SecretTransformer {
-	return func(secret *v1.Secret) *v1.Secret {
-		secret = secret.DeepCopy()
+	return func(secret *v1.Secret) {
 		labels := secret.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
@@ -88,6 +77,5 @@ func StripLabelsTransformer(keyPrefix string) SecretTransformer {
 			}
 		}
 		secret.SetLabels(labels)
-		return secret
 	}
 }

--- a/pkg/k8s/secrets/transformers_test.go
+++ b/pkg/k8s/secrets/transformers_test.go
@@ -13,20 +13,17 @@ func Test_UniqueNameTransformer_WithNameSet(t *testing.T) {
 
 	// SETUP
 	orig := fake.SecretWithType("name1", "secret1", v1.SecretTypeDockercfg)
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := UniqueNameTransformer()(origCopy)
+	UniqueNameTransformer()(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetName("")
 	expected.SetGenerateName("name1-")
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_SetAnnotationTransformer_SetNew(t *testing.T) {
@@ -34,21 +31,18 @@ func Test_SetAnnotationTransformer_SetNew(t *testing.T) {
 
 	// SETUP
 	orig := fake.SecretOpaque("name1", "secret1") // no annotations
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := SetAnnotationTransformer("foo", "bar")(origCopy)
+	SetAnnotationTransformer("foo", "bar")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetAnnotations(map[string]string{
 		"foo": "bar",
 	})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_SetAnnotationTransformer_OverwriteExisting(t *testing.T) {
@@ -59,21 +53,18 @@ func Test_SetAnnotationTransformer_OverwriteExisting(t *testing.T) {
 	orig.SetAnnotations(map[string]string{
 		"foo": "origValue1",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := SetAnnotationTransformer("foo", "newValue1")(origCopy)
+	SetAnnotationTransformer("foo", "newValue1")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetAnnotations(map[string]string{
 		"foo": "newValue1",
 	})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_StripAnnotationsTransformer_Match(t *testing.T) {
@@ -84,19 +75,16 @@ func Test_StripAnnotationsTransformer_Match(t *testing.T) {
 	orig.SetAnnotations(map[string]string{
 		"foo": "bar",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripAnnotationsTransformer("f")(origCopy)
+	StripAnnotationsTransformer("f")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetAnnotations(map[string]string{})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_StripAnnotationsTransformer_NoMatch(t *testing.T) {
@@ -107,16 +95,13 @@ func Test_StripAnnotationsTransformer_NoMatch(t *testing.T) {
 	orig.SetAnnotations(map[string]string{
 		"foo": "bar",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripAnnotationsTransformer("x")(origCopy)
+	StripAnnotationsTransformer("x")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
-	assert.DeepEqual(t, orig, result)
+	assert.DeepEqual(t, orig, transformed)
 }
 
 func Test_StripAnnotationsTransformer_NoExisting(t *testing.T) {
@@ -124,19 +109,16 @@ func Test_StripAnnotationsTransformer_NoExisting(t *testing.T) {
 
 	// SETUP
 	orig := fake.SecretOpaque("name1", "secret1") // no annotations
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripAnnotationsTransformer("f")(origCopy)
+	StripAnnotationsTransformer("f")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetAnnotations(map[string]string{})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_SetLabelTransformer_SetNew(t *testing.T) {
@@ -144,21 +126,18 @@ func Test_SetLabelTransformer_SetNew(t *testing.T) {
 
 	// SETUP
 	orig := fake.SecretOpaque("name1", "secret1") // no labels
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := SetLabelTransformer("foo", "bar")(origCopy)
+	SetLabelTransformer("foo", "bar")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetLabels(map[string]string{
 		"foo": "bar",
 	})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_SetLabelTransformer_OverwriteExisting(t *testing.T) {
@@ -169,21 +148,18 @@ func Test_SetLabelTransformer_OverwriteExisting(t *testing.T) {
 	orig.SetLabels(map[string]string{
 		"foo": "origValue1",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := SetLabelTransformer("foo", "newValue1")(origCopy)
+	SetLabelTransformer("foo", "newValue1")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetLabels(map[string]string{
 		"foo": "newValue1",
 	})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_StripLabelsTransformer_Match(t *testing.T) {
@@ -194,19 +170,16 @@ func Test_StripLabelsTransformer_Match(t *testing.T) {
 	orig.SetLabels(map[string]string{
 		"foo": "bar",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripLabelsTransformer("f")(origCopy)
+	StripLabelsTransformer("f")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetLabels(map[string]string{})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }
 
 func Test_StripLabelsTransformer_NoMatch(t *testing.T) {
@@ -217,16 +190,13 @@ func Test_StripLabelsTransformer_NoMatch(t *testing.T) {
 	orig.SetLabels(map[string]string{
 		"foo": "bar",
 	})
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripLabelsTransformer("x")(origCopy)
+	StripLabelsTransformer("x")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
-	assert.DeepEqual(t, orig, result)
+	assert.DeepEqual(t, orig, transformed)
 }
 
 func Test_StripLabelsTransformer_NoExisting(t *testing.T) {
@@ -234,17 +204,14 @@ func Test_StripLabelsTransformer_NoExisting(t *testing.T) {
 
 	// SETUP
 	orig := fake.SecretOpaque("name1", "secret1") // no annotations
-	origCopy := orig.DeepCopy()
+	transformed := orig.DeepCopy()
 
 	// EXERCISE
-	result := StripLabelsTransformer("f")(origCopy)
+	StripLabelsTransformer("f")(transformed)
 
 	// VERIFY
-	assert.DeepEqual(t, orig, origCopy)
-	assert.Assert(t, result != origCopy)
-
 	expected := orig.DeepCopy()
 	expected.SetLabels(map[string]string{})
 
-	assert.DeepEqual(t, expected, result)
+	assert.DeepEqual(t, expected, transformed)
 }


### PR DESCRIPTION
Instead of defining a rule that transformers must not modify the passed
object and return a pointer to a possibly modified copy, it's much
simpler, efficient and less error prone to let the function just modify
the object passed in. Then the caller is responsible for creating a copy
if needed.