### PR TITLE
Fix abort not cleaning up

### DIFF
--- a/backend-k8s/steward-system/202_deployment_steward-run-controller.yaml
+++ b/backend-k8s/steward-system/202_deployment_steward-run-controller.yaml
@@ -19,4 +19,4 @@ spec:
       containers:
       - name: steward-run-controller
         imagePullPolicy: IfNotPresent
-        image: stewardci/stewardci-run-controller:191210_6094acb
+        image: stewardci/stewardci-run-controller:191213_d10de05

--- a/backend-k8s/steward-system/202_deployment_steward-tenant-controller.yaml
+++ b/backend-k8s/steward-system/202_deployment_steward-tenant-controller.yaml
@@ -19,4 +19,4 @@ spec:
       containers:
       - name: steward-tenant-controller
         imagePullPolicy: IfNotPresent
-        image: stewardci/stewardci-tenant-controller:191210_6094acb
+        image: stewardci/stewardci-tenant-controller:191213_d10de05

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -199,10 +199,6 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	pipelineRun.AddFinalizer()
 
-	if pipelineRun.GetStatus().Result != api.ResultUndefined {
-		return nil
-	}
-
 	// Check if pipeline run is aborted
 	c.handleAborted(pipelineRun)
 
@@ -281,7 +277,7 @@ func (c *Controller) syncHandler(key string) error {
 // to trigger a cleanup.
 func (c *Controller) handleAborted(pipelineRun k8s.PipelineRun) {
 	intent := pipelineRun.GetSpec().Intent
-	if intent == api.IntentAbort {
+	if intent == api.IntentAbort && pipelineRun.GetStatus().Result == api.ResultUndefined {
 		pipelineRun.UpdateMessage("Aborted")
 		pipelineRun.UpdateResult(api.ResultAborted)
 		c.changeState(pipelineRun, api.StateCleaning)

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -206,6 +206,28 @@ func Test_Controller_syncHandler(t *testing.T) {
 			expectedResult:  "",
 			expectedState:   api.StateFinished,
 		},
+		{name: "cleanup_abborted_new",
+			pipelineSpec: api.PipelineSpec{
+				Intent: api.IntentAbort,
+			},
+			currentStatus: api.PipelineStatus{
+				State: api.StateUndefined,
+			},
+			runManagerError: nil,
+			expectedResult:  api.ResultAborted,
+			expectedState:   api.StateFinished,
+		},
+		{name: "cleanup_abborted_running",
+			pipelineSpec: api.PipelineSpec{
+				Intent: api.IntentAbort,
+			},
+			currentStatus: api.PipelineStatus{
+				State: api.StateRunning,
+			},
+			runManagerError: nil,
+			expectedResult:  api.ResultAborted,
+			expectedState:   api.StateFinished,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			test := test

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -336,6 +336,7 @@ func (c *runManager) GetRun(pipelineRun k8s.PipelineRun) (Run, error) {
 func (c *runManager) Cleanup(pipelineRun k8s.PipelineRun) error {
 	namespace := pipelineRun.GetRunNamespace()
 	if namespace == "" {
+		//TODO: Don't store on resource as message. Add it as event.
 		pipelineRun.StoreErrorAsMessage(fmt.Errorf("Nothing to clean up as namespace not set"), "")
 	} else {
 		err := c.namespaceManager.Delete(namespace)


### PR DESCRIPTION
Currently an aborted pipeline run stays in state cleaning forever.

This change is fixing it.