### PR TITLE
Fix sync handler synchronization

### DIFF
--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -250,21 +250,6 @@ func (mr *MockPipelineRunMockRecorder) DeleteFinalizerIfExists() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFinalizerIfExists", reflect.TypeOf((*MockPipelineRun)(nil).DeleteFinalizerIfExists))
 }
 
-// FinishState mocks base method
-func (m *MockPipelineRun) FinishState() (*v1alpha1.StateItem, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinishState")
-	ret0, _ := ret[0].(*v1alpha1.StateItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FinishState indicates an expected call of FinishState
-func (mr *MockPipelineRunMockRecorder) FinishState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishState", reflect.TypeOf((*MockPipelineRun)(nil).FinishState))
-}
-
 // GetKey mocks base method
 func (m *MockPipelineRun) GetKey() string {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -231,6 +231,12 @@ func Test_pipelineRun_FinishState_HistoryIfUpdateStateCalledBefore(t *testing.T)
 	start := status.StateHistory[1].StartedAt
 	end := status.StateHistory[1].FinishedAt
 	assert.Assert(t, factory.CheckTimeOrder(start, end))
+
+	assert.Equal(t, api.StateFinished, status.State)
+	start = status.StateDetails.StartedAt
+	end = status.StateDetails.FinishedAt
+	assert.Assert(t, factory.CheckTimeOrder(start, end))
+
 }
 
 func Test_pipelineRun_UpdateResult(t *testing.T) {

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -210,7 +210,7 @@ func Test_pipelineRun_UpdateState_AfterSecondCall(t *testing.T) {
 	assert.Assert(t, factory.CheckTimeOrder(start, end))
 }
 
-func Test_pipelineRun_FinishState_HistoryIfUpdateStateCalledBefore(t *testing.T) {
+func Test_pipelineRun_UpdateStateToFinished_HistoryIfUpdateStateCalledBefore(t *testing.T) {
 	t.Parallel()
 	// SETUP
 	pipelineRun := newPipelineRunWithEmptySpec(ns1, run1)
@@ -221,7 +221,7 @@ func Test_pipelineRun_FinishState_HistoryIfUpdateStateCalledBefore(t *testing.T)
 	factory.Sleep("let time elapse to check timestamps afterwards")
 
 	// EXERCISE
-	examinee.FinishState()
+	examinee.UpdateState(api.StateFinished)
 
 	// VERIFY
 	status := examinee.GetStatus()
@@ -233,10 +233,7 @@ func Test_pipelineRun_FinishState_HistoryIfUpdateStateCalledBefore(t *testing.T)
 	assert.Assert(t, factory.CheckTimeOrder(start, end))
 
 	assert.Equal(t, api.StateFinished, status.State)
-	start = status.StateDetails.StartedAt
-	end = status.StateDetails.FinishedAt
-	assert.Assert(t, factory.CheckTimeOrder(start, end))
-
+	assert.Equal(t, status.StateDetails.StartedAt, status.StateDetails.FinishedAt)
 }
 
 func Test_pipelineRun_UpdateResult(t *testing.T) {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -210,7 +210,7 @@ func (c *Controller) syncHandler(key string) error {
 	c.handleAborted(pipelineRun)
 
 	// As soon as we have a result we can cleanup
-	if pipelineRun.GetStatus().Result != api.ResultUndefined {
+	if pipelineRun.GetStatus().Result != api.ResultUndefined && pipelineRun.GetStatus().State != api.StateCleaning {
 		c.changeState(pipelineRun, api.StateCleaning)
 	}
 

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -143,26 +143,13 @@ func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) e
 		log.Printf("Failed to UpdateState: %q", err.Error())
 		return err
 	}
-	c.recordStateDuration(oldState)
-	return nil
-}
-
-func (c *Controller) finishState(pipelineRun k8s.PipelineRun) error {
-	oldState, err := pipelineRun.FinishState()
-	if err != nil {
-		return err
-	}
-	c.recordStateDuration(oldState)
-	return nil
-}
-
-func (c *Controller) recordStateDuration(state *api.StateItem) {
-	if state != nil {
-		err := c.metrics.ObserveDurationByState(state)
+	if oldState != nil {
+		err := c.metrics.ObserveDurationByState(oldState)
 		if err != nil {
-			log.Printf("Faild to measure state '%+v': '%s'", state, err)
+			log.Printf("Faild to measure state '%+v': '%s'", oldState, err)
 		}
 	}
+	return nil
 }
 
 func (c *Controller) createRunManager(pipelineRun k8s.PipelineRun) RunManager {
@@ -302,7 +289,7 @@ func (c *Controller) syncHandler(key string) error {
 	case api.StateCleaning:
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			err = c.finishState(pipelineRun)
+			err = c.changeState(pipelineRun, api.StateFinished)
 		}
 		return err
 	default:

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -302,7 +302,7 @@ func (c *Controller) syncHandler(key string) error {
 	case api.StateCleaning:
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			c.finishState(pipelineRun)
+			err = c.finishState(pipelineRun)
 		}
 		return err
 	default:

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -140,12 +140,13 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
 	oldState, err := pipelineRun.UpdateState(state)
 	if err != nil {
+		log.Printf("Failed to UpdateState: %q", err.Error())
 		return err
 	}
 	if oldState != nil {
 		err = c.metrics.ObserveDurationByState(oldState)
 		if err != nil {
-			log.Printf("Faild to measure state '%+v': '%s'", oldState, err)
+			log.Printf("Failed to measure state '%+v': '%s'", oldState, err)
 		}
 	}
 	return nil
@@ -162,6 +163,7 @@ func (c *Controller) createRunManager(pipelineRun k8s.PipelineRun) RunManager {
 // converge the two. It then updates the Status block of the Foo resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
+	// Initial checks on cached pipelineRun
 	pipelineRunAPIObj, err := c.pipelineRunFetcher.ByKey(key)
 	if err != nil {
 		return err
@@ -170,12 +172,12 @@ func (c *Controller) syncHandler(key string) error {
 	if pipelineRunAPIObj == nil {
 		return nil
 	}
-
 	// fast exit
 	if pipelineRunAPIObj.Status.State == api.StateFinished && pipelineRunAPIObj.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
+	// Get real pipelineRun bypassing cache
 	pipelineRun, err := k8s.NewPipelineRun(pipelineRunAPIObj, c.factory)
 
 	if err != nil {
@@ -220,36 +222,48 @@ func (c *Controller) syncHandler(key string) error {
 	// Those must be recovered.
 	case api.StateUndefined:
 		c.metrics.CountStart()
-		c.changeState(pipelineRun, api.StatePreparing)
+		if err = c.changeState(pipelineRun, api.StatePreparing); err != nil {
+			return err
+		}
 		err = runManager.Start(pipelineRun)
 		if err != nil {
 			pipelineRun.StoreErrorAsMessage(err, "error syncing resource")
 			if pipelineRun.GetStatus().Result == api.ResultUndefined {
 				pipelineRun.UpdateResult(api.ResultErrorInfra)
 			}
-			c.changeState(pipelineRun, api.StateCleaning)
+			if err = c.changeState(pipelineRun, api.StateCleaning); err != nil {
+				return err
+			}
 			c.metrics.CountResult(pipelineRun.GetStatus().Result)
 			return nil
 		}
-		c.changeState(pipelineRun, api.StateWaiting)
+		if err = c.changeState(pipelineRun, api.StateWaiting); err != nil {
+			return err
+		}
 	case api.StateWaiting:
 		run, err := runManager.GetRun(pipelineRun)
 		if err != nil {
 			pipelineRun.StoreErrorAsMessage(err, "error syncing resource")
-			c.changeState(pipelineRun, api.StateCleaning)
+			if err = c.changeState(pipelineRun, api.StateCleaning); err != nil {
+				return err
+			}
 			pipelineRun.UpdateResult(api.ResultErrorInfra)
 			c.metrics.CountResult(api.ResultErrorInfra)
 			return nil
 		}
 		started := run.GetStartTime()
 		if started != nil {
-			c.changeState(pipelineRun, api.StateRunning)
+			if err = c.changeState(pipelineRun, api.StateRunning); err != nil {
+				return err
+			}
 		}
 	case api.StateRunning:
 		run, err := runManager.GetRun(pipelineRun)
 		if err != nil {
 			pipelineRun.StoreErrorAsMessage(err, "error syncing resource")
-			c.changeState(pipelineRun, api.StateCleaning)
+			if err = c.changeState(pipelineRun, api.StateCleaning); err != nil {
+				return err
+			}
 			return nil
 		}
 		containerInfo := run.GetContainerInfo()
@@ -267,13 +281,17 @@ func (c *Controller) syncHandler(key string) error {
 			}
 			pipelineRun.UpdateMessage(msg)
 			pipelineRun.UpdateResult(result)
-			c.changeState(pipelineRun, api.StateCleaning)
+			if err = c.changeState(pipelineRun, api.StateCleaning); err != nil {
+				return err
+			}
 			c.metrics.CountResult(result)
 		}
 	case api.StateCleaning:
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			c.changeState(pipelineRun, api.StateFinished)
+			if err = c.changeState(pipelineRun, api.StateFinished); err != nil {
+				return err
+			}
 		}
 		return err
 	default:

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -355,7 +355,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 
 	assert.Assert(t, status != nil)
 	assert.Equal(t, api.StateFinished, status.State)
-	assert.Equal(t, api.StateCleaning, status.StateDetails.State)
+	assert.Equal(t, status.State, status.StateDetails.State)
 	assert.Equal(t, api.ResultTimeout, status.Result)
 	assert.Equal(t, "message from Succeeded condition", status.Message)
 }

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -355,7 +355,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 
 	assert.Assert(t, status != nil)
 	assert.Equal(t, api.StateFinished, status.State)
-	assert.Equal(t, status.State, status.StateDetails.State)
+	assert.Equal(t, api.StateCleaning, status.StateDetails.State)
 	assert.Equal(t, api.ResultTimeout, status.Result)
 	assert.Equal(t, "message from Succeeded condition", status.Message)
 }

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -345,7 +345,6 @@ func (c *runManager) Cleanup(pipelineRun k8s.PipelineRun) error {
 			return err
 		}
 	}
-	pipelineRun.FinishState()
 	return nil
 }
 

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -158,7 +158,6 @@ func Test_RunManager_Start_FailsWithContentErrorWhenPipelineCloneSecretNotFound(
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().FinishState()
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -181,7 +180,6 @@ func Test_RunManager_Start_FailsWithContentErrorWhenSecretNotFound(t *testing.T)
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().FinishState()
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -205,7 +203,6 @@ func Test_RunManager_Start_FailsWithContentErrorWhenImagePullSecretNotFound(t *t
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().FinishState()
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -231,7 +228,6 @@ func Test_RunManager_Start_FailsWithInfraErrorWhenForbidden(t *testing.T) {
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, fmt.Errorf("Forbidden"))
 	mockPipelineRun.EXPECT().UpdateMessage("Forbidden")
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorInfra)
-	mockPipelineRun.EXPECT().FinishState()
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -245,7 +241,6 @@ func Test_RunManager_Cleanup_RemovesNamespace(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockFactory, mockPipelineRun, mockSecretProvider, mockNamespaceManager := prepareMocks(mockCtrl)
 	preparePredefinedClusterRole(t, mockFactory, mockPipelineRun)
-	mockPipelineRun.EXPECT().FinishState()
 
 	examinee := NewRunManager(mockFactory, mockSecretProvider, mockNamespaceManager).(*runManager)
 	err := examinee.prepareRunNamespace(mockPipelineRun)
@@ -445,9 +440,6 @@ func Test_RunManager_Log_Elasticsearch(t *testing.T) {
 }
 
 func preparePredefinedClusterRole(t *testing.T, factory *mocks.MockClientFactory, pipelineRun *mocks.MockPipelineRun) {
-	// Uncomment this if unexpected call to FinishState() swallows the error you want to see
-	// pipelineRun.EXPECT().FinishState().AnyTimes()
-
 	// Create expected cluster role
 	_, err := factory.RbacV1beta1().ClusterRoles().Create(k8sfake.ClusterRole(string(runClusterRoleName)))
 	assert.NilError(t, err)

--- a/test/integrationtest/pipelineRun_testbuilders.go
+++ b/test/integrationtest/pipelineRun_testbuilders.go
@@ -31,7 +31,7 @@ func PipelineRunAbort(Namespace string) f.PipelineRunTest {
 				builder.Abort(),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultAborted),
-		Timeout: 10 * time.Second,
+		Timeout: 15 * time.Second,
 	}
 
 }

--- a/test/loadtest/pipelineRun_finishedPipelines_test.go
+++ b/test/loadtest/pipelineRun_finishedPipelines_test.go
@@ -5,6 +5,7 @@ package loadtest
 import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"testing"
+"time"
 
 	f "github.com/SAP/stewardci-core/test/framework"
 	test "github.com/SAP/stewardci-core/test/integrationtest"
@@ -14,7 +15,19 @@ func Test_ClusterWithFinishedPipelines(t *testing.T) {
 	tests := []f.TestPlan{
 		f.TestPlan{TestBuilder: test.PipelineRunAbort,
 			Count: 100,
+                        CreationDelay: time.Duration(1 * time.Second),
 		},
 	}
 	f.ExecutePipelineRunTests(t, tests...)
 }
+
+func Test_ClusterWithWrongUrl(t *testing.T) {
+        tests := []f.TestPlan{
+                f.TestPlan{TestBuilder: test.PipelineRunWrongJenkinsfileRepo,
+                        Count: 1000,
+                        CreationDelay: time.Duration(1 * time.Second),
+                },
+        }
+        f.ExecutePipelineRunTests(t, tests...)
+}
+

--- a/test/loadtest/pipelineRun_finishedPipelines_test.go
+++ b/test/loadtest/pipelineRun_finishedPipelines_test.go
@@ -5,7 +5,7 @@ package loadtest
 import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"testing"
-"time"
+	"time"
 
 	f "github.com/SAP/stewardci-core/test/framework"
 	test "github.com/SAP/stewardci-core/test/integrationtest"
@@ -14,20 +14,19 @@ import (
 func Test_ClusterWithFinishedPipelines(t *testing.T) {
 	tests := []f.TestPlan{
 		f.TestPlan{TestBuilder: test.PipelineRunAbort,
-			Count: 100,
-                        CreationDelay: time.Duration(1 * time.Second),
+			Count:         100,
+			CreationDelay: time.Duration(1 * time.Second),
 		},
 	}
 	f.ExecutePipelineRunTests(t, tests...)
 }
 
 func Test_ClusterWithWrongUrl(t *testing.T) {
-        tests := []f.TestPlan{
-                f.TestPlan{TestBuilder: test.PipelineRunWrongJenkinsfileRepo,
-                        Count: 1000,
-                        CreationDelay: time.Duration(1 * time.Second),
-                },
-        }
-        f.ExecutePipelineRunTests(t, tests...)
+	tests := []f.TestPlan{
+		f.TestPlan{TestBuilder: test.PipelineRunWrongJenkinsfileRepo,
+			Count:         1000,
+			CreationDelay: time.Duration(1 * time.Second),
+		},
+	}
+	f.ExecutePipelineRunTests(t, tests...)
 }
-

--- a/test/loadtest/pipelineRun_parallel_test.go
+++ b/test/loadtest/pipelineRun_parallel_test.go
@@ -30,7 +30,7 @@ func Test_Loadtest_delay(t *testing.T) {
 	f.ExecutePipelineRunTests(t, tests...)
 }
 
-func Test_Loadtest(t *testing.T) {
+func Test_Loadtest_ok(t *testing.T) {
 	f.ExecutePipelineRunTests(t,
 		f.TestPlan{
 			TestBuilder: test.PipelineRunOK,


### PR DESCRIPTION
# pipelineRun
- UpdateState changed to atomic change
- FinishState fixed to set StateDetails correctly and set State to StateFinished

# run controller
- Only set State to Cleaning if not already on Cleaning
- Proper errror handling for failing changeState
- Proper error handling for finish State

# run manager
- Clenaup: move finishState to controller