### PR TITLE
Removed misleading log message from tenantNamespace.go

### DIFF
--- a/pkg/k8s/tenantNamespace.go
+++ b/pkg/k8s/tenantNamespace.go
@@ -25,8 +25,6 @@ func NewTenantNamespace(factory ClientFactory, namespace string) TenantNamespace
 	secretsClient := factory.CoreV1().Secrets(namespace)
 	pipelineRunClient := factory.StewardV1alpha1().PipelineRuns(namespace)
 	secretProvider := k8ssecretprovider.NewProvider(secretsClient, namespace)
-	log.Printf("Creating tenantNamespace: '%s'", namespace)
-
 	return &tenantNamespace{
 		secretProvider:    secretProvider,
 		pipelineRunClient: pipelineRunClient,


### PR DESCRIPTION
The log message is wrong and is confusing since it is also logged in the run controller.