### PR TITLE
Added missing context info to log entries

### DIFF
--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -250,6 +250,20 @@ func (mr *MockPipelineRunMockRecorder) DeleteFinalizerIfExists() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFinalizerIfExists", reflect.TypeOf((*MockPipelineRun)(nil).DeleteFinalizerIfExists))
 }
 
+// GetFullName mocks base method
+func (m *MockPipelineRun) GetFullName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFullName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetFullName indicates an expected call of GetFullName
+func (mr *MockPipelineRunMockRecorder) GetFullName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFullName", reflect.TypeOf((*MockPipelineRun)(nil).GetFullName))
+}
+
 // GetKey mocks base method
 func (m *MockPipelineRun) GetKey() string {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -250,20 +250,6 @@ func (mr *MockPipelineRunMockRecorder) DeleteFinalizerIfExists() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFinalizerIfExists", reflect.TypeOf((*MockPipelineRun)(nil).DeleteFinalizerIfExists))
 }
 
-// GetFullName mocks base method
-func (m *MockPipelineRun) GetFullName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFullName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetFullName indicates an expected call of GetFullName
-func (mr *MockPipelineRunMockRecorder) GetFullName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFullName", reflect.TypeOf((*MockPipelineRun)(nil).GetFullName))
-}
-
 // GetKey mocks base method
 func (m *MockPipelineRun) GetKey() string {
 	m.ctrl.T.Helper()
@@ -389,6 +375,20 @@ func (m *MockPipelineRun) StoreErrorAsMessage(arg0 error, arg1 string) error {
 func (mr *MockPipelineRunMockRecorder) StoreErrorAsMessage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreErrorAsMessage", reflect.TypeOf((*MockPipelineRun)(nil).StoreErrorAsMessage), arg0, arg1)
+}
+
+// String mocks base method
+func (m *MockPipelineRun) String() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "String")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// String indicates an expected call of String
+func (mr *MockPipelineRunMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockPipelineRun)(nil).String))
 }
 
 // UpdateContainer mocks base method

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -17,13 +17,13 @@ import (
 
 // PipelineRun is a wrapper for the K8s PipelineRun resource
 type PipelineRun interface {
+	fmt.Stringer
 	GetStatus() *api.PipelineStatus
 	GetSpec() *api.PipelineSpec
 	GetName() string
 	GetKey() string
 	GetRunNamespace() string
 	GetNamespace() string
-	GetFullName() string
 	GetPipelineRepoServerURL() (string, error)
 	HasDeletionTimestamp() bool
 	AddFinalizer() error
@@ -93,10 +93,10 @@ func (r *pipelineRun) GetPipelineRepoServerURL() (string, error) {
 	urlString := r.GetSpec().JenkinsFile.URL
 	repoURL, err := url.Parse(urlString)
 	if err != nil {
-		return "", errors.Wrapf(err, "value %q of field spec.jenkinsFile.url is invalid [%s]", urlString, r.GetFullName())
+		return "", errors.Wrapf(err, "value %q of field spec.jenkinsFile.url is invalid [%s]", urlString, r.String())
 	}
 	if !(repoURL.Scheme == "http") && !(repoURL.Scheme == "https") {
-		return "", fmt.Errorf("value %q of field spec.jenkinsFile.url is invalid: scheme not supported: %q [%s]", urlString, repoURL.Scheme, r.GetFullName())
+		return "", fmt.Errorf("value %q of field spec.jenkinsFile.url is invalid [%s]: scheme not supported: %q", urlString, r.String(), repoURL.Scheme)
 	}
 	return fmt.Sprintf("%s://%s", repoURL.Scheme, repoURL.Host), nil
 }
@@ -124,7 +124,7 @@ func (r *pipelineRun) GetSpec() *api.PipelineSpec {
 // Returns the state details of state A
 func (r *pipelineRun) UpdateState(state api.State) (*api.StateItem, error) {
 	r.ensureCopy()
-	log.Printf("New State %s [%s]", state, r.GetFullName())
+	log.Printf("Update State to %s [%s]", state, r.String())
 	now := metav1.Now()
 	oldstate := r.finishCurrentState()
 	newState := api.StateItem{State: state, StartedAt: now}
@@ -136,8 +136,9 @@ func (r *pipelineRun) UpdateState(state api.State) (*api.StateItem, error) {
 	return oldstate, r.updateStatus()
 }
 
-func (r *pipelineRun) GetFullName() string {
-	return r.apiObj.GetNamespace() + "/" + r.apiObj.GetName()
+// String returns the full qualified name of the pipeline run
+func (r *pipelineRun) String() string {
+	return fmt.Sprintf("PipelineRun{name: %s, namespace: %s, state: %s}", r.GetName(), r.GetNamespace(), string(r.GetStatus().State))
 }
 
 func (r *pipelineRun) finishCurrentState() *api.StateItem {
@@ -179,7 +180,7 @@ func (r *pipelineRun) UpdateContainer(c *corev1.ContainerState) error {
 // StoreErrorAsMessage stores the error as message in the status
 func (r *pipelineRun) StoreErrorAsMessage(err error, message string) error {
 	if err != nil {
-		text := fmt.Sprintf("ERROR: %s (%s - state:%s): %s", utils.Trim(message), r.GetFullName(), string(r.GetStatus().State), err.Error())
+		text := fmt.Sprintf("ERROR: %s [%s]: %s", utils.Trim(message), r.String(), err.Error())
 		log.Printf(text)
 		return r.UpdateMessage(text)
 	}
@@ -232,14 +233,14 @@ func (r *pipelineRun) DeleteFinalizerIfExists() error {
 
 func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 	if r.client == nil {
-		return fmt.Errorf("No factory provided to store updates [%s]", r.GetFullName())
+		return fmt.Errorf("No factory provided to store updates [%s]", r.String())
 	}
 	r.ensureCopy()
 	r.apiObj.ObjectMeta.Finalizers = finalizerList
 	result, err := r.client.Update(r.apiObj)
 	if err != nil {
 		return errors.Wrap(err,
-			fmt.Sprintf("Failed to update finalizers of PipelineRun '%s'", r.GetFullName()))
+			fmt.Sprintf("Failed to update finalizers [%s]", r.String()))
 	}
 	r.apiObj = result
 	return nil
@@ -247,12 +248,12 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 
 func (r *pipelineRun) updateStatus() error {
 	if r.client == nil {
-		return fmt.Errorf("No factory provided to store updates [%s]", r.GetFullName())
+		return fmt.Errorf("No factory provided to store updates [%s]", r.String())
 	}
 	result, err := r.client.UpdateStatus(r.apiObj)
 	if err != nil {
 		return errors.Wrap(err,
-			fmt.Sprintf("Failed to update status of PipelineRun '%s'", r.GetFullName()))
+			fmt.Sprintf("Failed to update status [%s]", r.String()))
 	}
 	r.apiObj = result
 	return nil

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -122,7 +122,7 @@ func Test_StoreErrorAsMessage(t *testing.T) {
 	client := factory.StewardV1alpha1().PipelineRuns(ns1)
 	run, err = client.Get("foo", metav1.GetOptions{})
 	assert.NilError(t, err)
-	assert.Equal(t, "ERROR: message1 (namespace1/foo - state:running): error1", run.Status.Message)
+	assert.Equal(t, "ERROR: message1 [PipelineRun{name: foo, namespace: namespace1, state: running}]: error1", run.Status.Message)
 }
 
 func Test_HasDeletionTimestamp_false(t *testing.T) {
@@ -262,7 +262,7 @@ func Test_pipelineRun_UpdateResult_noFactory(t *testing.T) {
 	// EXERCISE
 	err = examinee.UpdateResult(api.ResultSuccess)
 	// VERIFY
-	assert.Equal(t, "No factory provided to store updates [namespace1/pipelinerun1]", err.Error())
+	assert.Equal(t, "No factory provided to store updates [PipelineRun{name: pipelinerun1, namespace: namespace1, state: }]", err.Error())
 }
 
 func Test_pipelineRun_GetPipelineRepoServerURL_CorrectURLs(t *testing.T) {
@@ -297,8 +297,8 @@ func Test_pipelineRun_GetPipelineRepoServerURL_WrongURLs(t *testing.T) {
 		url                  string
 		expectedErrorPattern string
 	}{
-		{url: "&:", expectedErrorPattern: `value "&:" of field spec.jenkinsFile.url is invalid \[namespace1/pipelinerun1\]: .*`},
-		{url: "ftp://foo/bar", expectedErrorPattern: `value "ftp://foo/bar" of field spec.jenkinsFile.url is invalid: scheme not supported: .*`},
+		{url: "&:", expectedErrorPattern: `value "&:" of field spec.jenkinsFile.url is invalid \[.*\]: .*`},
+		{url: "ftp://foo/bar", expectedErrorPattern: `value "ftp://foo/bar" of field spec.jenkinsFile.url is invalid \[.*\]: scheme not supported: .*`},
 	} {
 		t.Run(test.url, func(t *testing.T) {
 			// SETUP

--- a/pkg/k8s/tenantNamespace.go
+++ b/pkg/k8s/tenantNamespace.go
@@ -1,8 +1,6 @@
 package k8s
 
 import (
-	"log"
-
 	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/client/clientset/versioned/typed/steward/v1alpha1"
 	secrets "github.com/SAP/stewardci-core/pkg/k8s/secrets"
 	k8ssecretprovider "github.com/SAP/stewardci-core/pkg/k8s/secrets/providers/k8s"

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -146,7 +146,7 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
 	oldState, err := pipelineRun.UpdateState(state)
 	if err != nil {
-		log.Printf("Failed to UpdateState of %q to %q: %q", pipelineRun.GetFullName(), state, err.Error())
+		log.Printf("Failed to UpdateState of %q to %q: %q", pipelineRun.String(), state, err.Error())
 		return err
 	}
 	if oldState != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -146,7 +146,7 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
 	oldState, err := pipelineRun.UpdateState(state)
 	if err != nil {
-		log.Printf("Failed to UpdateState of %q to %q: %q", pipelineRun.String(), state, err.Error())
+		log.Printf("Failed to UpdateState of [%s] to %q: %q", pipelineRun.String(), state, err.Error())
 		return err
 	}
 	if oldState != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -146,7 +146,7 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
 	oldState, err := pipelineRun.UpdateState(state)
 	if err != nil {
-		log.Printf("Failed to UpdateState: %q", err.Error())
+		log.Printf("Failed to UpdateState of %q to %q: %q", pipelineRun.GetFullName(), state, err.Error())
 		return err
 	}
 	if oldState != nil {

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -191,7 +191,7 @@ func (c *runManager) copyPipelineCloneSecret(pipelineRun k8s.PipelineRun, secret
 func (c *runManager) copySecrets(secretHelper secrets.SecretHelper, secretNames []string, pipelineRun k8s.PipelineRun, filter secrets.SecretFilter, transformers ...secrets.SecretTransformer) ([]string, error) {
 	storedSecretNames, err := secretHelper.CopySecrets(secretNames, filter, transformers...)
 	if err != nil {
-		log.Printf("cannot copy secrets %s for pipelineRun %s/%s. Error: %s", secretNames, pipelineRun.GetNamespace(), pipelineRun.GetName(), err)
+		log.Printf("Cannot copy secrets %s for %s. Error: %s", secretNames, pipelineRun.String(), err)
 		pipelineRun.UpdateMessage(err.Error())
 		if secretHelper.IsNotFound(err) {
 			pipelineRun.UpdateResult(v1alpha1.ResultErrorContent)

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -191,7 +191,7 @@ func (c *runManager) copyPipelineCloneSecret(pipelineRun k8s.PipelineRun, secret
 func (c *runManager) copySecrets(secretHelper secrets.SecretHelper, secretNames []string, pipelineRun k8s.PipelineRun, filter secrets.SecretFilter, transformers ...secrets.SecretTransformer) ([]string, error) {
 	storedSecretNames, err := secretHelper.CopySecrets(secretNames, filter, transformers...)
 	if err != nil {
-		log.Printf("cannot copy secrets %s: %s", secretNames, err)
+		log.Printf("cannot copy secrets %s for pipelineRun %s/%s. Error: %s", secretNames, pipelineRun.GetNamespace(), pipelineRun.GetName(), err)
 		pipelineRun.UpdateMessage(err.Error())
 		if secretHelper.IsNotFound(err) {
 			pipelineRun.UpdateResult(v1alpha1.ResultErrorContent)

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -191,7 +191,7 @@ func (c *runManager) copyPipelineCloneSecret(pipelineRun k8s.PipelineRun, secret
 func (c *runManager) copySecrets(secretHelper secrets.SecretHelper, secretNames []string, pipelineRun k8s.PipelineRun, filter secrets.SecretFilter, transformers ...secrets.SecretTransformer) ([]string, error) {
 	storedSecretNames, err := secretHelper.CopySecrets(secretNames, filter, transformers...)
 	if err != nil {
-		log.Printf("Cannot copy secrets %s for %s. Error: %s", secretNames, pipelineRun.String(), err)
+		log.Printf("Cannot copy secrets %s for [%s]. Error: %s", secretNames, pipelineRun.String(), err)
 		pipelineRun.UpdateMessage(err.Error())
 		if secretHelper.IsNotFound(err) {
 			pipelineRun.UpdateResult(v1alpha1.ResultErrorContent)

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -158,8 +158,7 @@ func Test_RunManager_Start_FailsWithContentErrorWhenPipelineCloneSecretNotFound(
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().GetNamespace() //logging
-	mockPipelineRun.EXPECT().GetName()      //logging
+	mockPipelineRun.EXPECT().String() //logging
 
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
@@ -183,8 +182,7 @@ func Test_RunManager_Start_FailsWithContentErrorWhenSecretNotFound(t *testing.T)
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().GetNamespace() //logging
-	mockPipelineRun.EXPECT().GetName()      //logging
+	mockPipelineRun.EXPECT().String() //logging
 
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
@@ -209,8 +207,7 @@ func Test_RunManager_Start_FailsWithContentErrorWhenImagePullSecretNotFound(t *t
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
-	mockPipelineRun.EXPECT().GetNamespace() //logging
-	mockPipelineRun.EXPECT().GetName()      //logging
+	mockPipelineRun.EXPECT().String() //logging
 
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
@@ -237,8 +234,7 @@ func Test_RunManager_Start_FailsWithInfraErrorWhenForbidden(t *testing.T) {
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, fmt.Errorf("Forbidden"))
 	mockPipelineRun.EXPECT().UpdateMessage("Forbidden")
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorInfra)
-	mockPipelineRun.EXPECT().GetNamespace() //logging
-	mockPipelineRun.EXPECT().GetName()      //logging
+	mockPipelineRun.EXPECT().String() //logging
 
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -158,6 +158,9 @@ func Test_RunManager_Start_FailsWithContentErrorWhenPipelineCloneSecretNotFound(
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
+	mockPipelineRun.EXPECT().GetNamespace() //logging
+	mockPipelineRun.EXPECT().GetName()      //logging
+
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -180,6 +183,9 @@ func Test_RunManager_Start_FailsWithContentErrorWhenSecretNotFound(t *testing.T)
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
+	mockPipelineRun.EXPECT().GetNamespace() //logging
+	mockPipelineRun.EXPECT().GetName()      //logging
+
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -203,6 +209,9 @@ func Test_RunManager_Start_FailsWithContentErrorWhenImagePullSecretNotFound(t *t
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, nil)
 	mockPipelineRun.EXPECT().UpdateMessage(secrets.NewNotFoundError(secretName).Error())
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorContent)
+	mockPipelineRun.EXPECT().GetNamespace() //logging
+	mockPipelineRun.EXPECT().GetName()      //logging
+
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)
@@ -228,6 +237,9 @@ func Test_RunManager_Start_FailsWithInfraErrorWhenForbidden(t *testing.T) {
 	mockSecretProvider.EXPECT().GetSecret(secretName).Return(nil, fmt.Errorf("Forbidden"))
 	mockPipelineRun.EXPECT().UpdateMessage("Forbidden")
 	mockPipelineRun.EXPECT().UpdateResult(steward.ResultErrorInfra)
+	mockPipelineRun.EXPECT().GetNamespace() //logging
+	mockPipelineRun.EXPECT().GetName()      //logging
+
 	// EXERCISE
 	err := examinee.Start(mockPipelineRun)
 	assert.Assert(t, err != nil)


### PR DESCRIPTION
Some log entries are useless without context information like which pipelineRun is affected.