### PR TITLE
Add deletion result for clean metrics

### DIFF
--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -182,6 +182,8 @@ const (
 	ResultAborted Result = "aborted"
 	// ResultTimeout - the pipeline run timed out
 	ResultTimeout Result = "timeout"
+	// ResultDeleted - the pipeline run was deleted
+	ResultDeleted Result = "deleted"
 )
 
 // Intent denotes how the pipeline run should be handled

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -204,7 +204,10 @@ func (c *Controller) syncHandler(key string) error {
 		runManager := c.createRunManager(pipelineRun)
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			pipelineRun.DeleteFinalizerIfExists()
+			err = pipelineRun.DeleteFinalizerIfExists()
+			if err == nil {
+				c.metrics.CountResult(api.ResultDeleted)
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
Currently a pipeline run which is deleted is not counted in the
_steward_pipelineruns_completed_total_ metric.

This is fixed with this change.