### PR TITLE
Add psp for pipeline runs

### DIFF
--- a/charts/steward/templates/clusterrole-run.yaml
+++ b/charts/steward/templates/clusterrole-run.yaml
@@ -17,3 +17,7 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get","list","watch"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames: ['steward-run']

--- a/charts/steward/templates/run-podsecuritypolicy.yaml
+++ b/charts/steward/templates/run-podsecuritypolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: steward-run
+  labels:
+    {{- include "steward.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  allowPrivilegeEscalation: false
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  seLinux:
+    rule: 'RunAsAny'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  hostPorts: # do not allow host ports
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI


### PR DESCRIPTION
This change will make Steward work on clusters where pod security
policies are enabled.
Currently, root users are permitted, but that will changed later.

If pod security policies are not enabled in the cluster, this change
will do no harm.