### PR TITLE
Enable elasticsearch details inx integration tests

### DIFF
--- a/test/builder/pipelineRun.go
+++ b/test/builder/pipelineRun.go
@@ -134,3 +134,15 @@ func Abort() PipelineRunSpecOp {
 		return spec
 	}
 }
+
+// Logging creates a PipelineRunSpecOp which adds Logging to the PipelineRun
+func Logging(runID *api.CustomJSON) PipelineRunSpecOp {
+	return func(spec api.PipelineSpec) api.PipelineSpec {
+		spec.Logging = &api.Logging{
+			Elasticsearch: &api.Elasticsearch{
+				RunID: runID,
+			},
+		}
+		return spec
+	}
+}

--- a/test/framework/pipelineRun_helper.go
+++ b/test/framework/pipelineRun_helper.go
@@ -38,7 +38,7 @@ func executePipelineRunTests(ctx context.Context, t *testing.T, testPlans ...Tes
 			name :=
 				fmt.Sprintf("%s_%d", getTestPlanName(testPlan), i)
 			ctx = SetTestName(ctx, name)
-			runID := &api.CustomJSON{map[string]string{"name": name}}
+			runID := &api.CustomJSON{map[string]string{"buildId": name}}
 
 			pipelineTest := testPlan.TestBuilder(tnn, runID)
 

--- a/test/framework/pipelineRun_helper.go
+++ b/test/framework/pipelineRun_helper.go
@@ -38,7 +38,9 @@ func executePipelineRunTests(ctx context.Context, t *testing.T, testPlans ...Tes
 			name :=
 				fmt.Sprintf("%s_%d", getTestPlanName(testPlan), i)
 			ctx = SetTestName(ctx, name)
-			pipelineTest := testPlan.TestBuilder(tnn)
+			runID := &api.CustomJSON{map[string]string{"name": name}}
+
+			pipelineTest := testPlan.TestBuilder(tnn, runID)
 
 			ctx, cancel := context.WithTimeout(ctx, pipelineTest.Timeout)
 			defer cancel()

--- a/test/framework/pipelineRun_helper_test.go
+++ b/test/framework/pipelineRun_helper_test.go
@@ -23,7 +23,7 @@ func setupTestContext() context.Context {
 	return SetClientFactory(ctx, factory)
 }
 
-func pipelineWithStatusSuccess(namespace string) PipelineRunTest {
+func pipelineWithStatusSuccess(namespace string, buildID *api.CustomJSON) PipelineRunTest {
 	randomName, _ := utils.RandomAlphaNumString(5)
 	pipelineRun := pipelineRun(randomName, namespace)
 	pipelineRun.Status = api.PipelineStatus{Result: api.ResultSuccess}

--- a/test/framework/pipelineRun_testbuilders.go
+++ b/test/framework/pipelineRun_testbuilders.go
@@ -21,7 +21,8 @@ type PipelineRunTest struct {
 }
 
 // PipelineRunTestBuilder is a funciton creating a PipelineRunTest for a defined Namespace
-type PipelineRunTestBuilder = func(string) PipelineRunTest
+// and a buildID for the elasticsearch
+type PipelineRunTestBuilder = func(string, *api.CustomJSON) PipelineRunTest
 
 // TestPlan defines a test plan
 type TestPlan struct {

--- a/test/framework/pipelineRun_testbuilders_test.go
+++ b/test/framework/pipelineRun_testbuilders_test.go
@@ -5,13 +5,15 @@ import (
 	"time"
 
 	"gotest.tools/assert"
+
+	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 )
 
-func Bar(string) PipelineRunTest {
+func Bar(string, *api.CustomJSON) PipelineRunTest {
 	return PipelineRunTest{}
 }
 
-func Baz(string) PipelineRunTest {
+func Baz(string, *api.CustomJSON) PipelineRunTest {
 	return PipelineRunTest{}
 }
 

--- a/test/integrationtest/pipelineRun_testbuilders.go
+++ b/test/integrationtest/pipelineRun_testbuilders.go
@@ -24,10 +24,11 @@ var AllTestBuilders = []f.PipelineRunTestBuilder{
 const pipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
 
 // PipelineRunAbort is a PipelineRunTestBuilder to build a PipelineRunTest with aborted pipeline
-func PipelineRunAbort(Namespace string) f.PipelineRunTest {
+func PipelineRunAbort(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("sleep-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.Abort(),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"sleep/Jenkinsfile"),
@@ -39,10 +40,11 @@ func PipelineRunAbort(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunSleep is a PipelineRunTestBuilder to build PipelineRunTest which sleeps for one second
-func PipelineRunSleep(Namespace string) f.PipelineRunTest {
+func PipelineRunSleep(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("sleep-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"sleep/Jenkinsfile"),
 				builder.ArgSpec("SLEEP_FOR_SECONDS", "1"),
@@ -53,10 +55,11 @@ func PipelineRunSleep(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunFail is a PipelineRunTestBuilder to build PipelineRunTest which fails
-func PipelineRunFail(Namespace string) f.PipelineRunTest {
+func PipelineRunFail(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("error-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"error/Jenkinsfile"),
 			)),
@@ -66,10 +69,11 @@ func PipelineRunFail(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunOK is a PipelineRunTestBuilder to build PipelineRunTest which succeeds
-func PipelineRunOK(Namespace string) f.PipelineRunTest {
+func PipelineRunOK(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("ok-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"success/Jenkinsfile"),
 
@@ -81,10 +85,11 @@ func PipelineRunOK(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunWithSecret is a PipelineRunTestBuilder to build PipelineRunTest which uses Secrets
-func PipelineRunWithSecret(Namespace string) f.PipelineRunTest {
+func PipelineRunWithSecret(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("with-secret-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"secret/Jenkinsfile"),
 				builder.ArgSpec("SECRETID", "with-secret-foo"),
@@ -99,10 +104,11 @@ func PipelineRunWithSecret(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunMissingSecret is a PipelineRunTestBuilder to build PipelineRunTest which uses Secrets
-func PipelineRunMissingSecret(Namespace string) f.PipelineRunTest {
+func PipelineRunMissingSecret(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("missing-secret-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"secret/Jenkinsfile"),
 				builder.ArgSpec("SECRETID", "foo"),
@@ -116,10 +122,11 @@ func PipelineRunMissingSecret(Namespace string) f.PipelineRunTest {
 }
 
 // PipelineRunWrongJenkinsfileRepo is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile repo url
-func PipelineRunWrongJenkinsfileRepo(Namespace string) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfileRepo(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-repo-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
 					"Jenkinsfile"),
 			)),
@@ -132,10 +139,11 @@ fatal: could not read Username for 'https://github.com': No such device or addre
 }
 
 // PipelineRunWrongJenkinsfileRepoWithUser is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile repo url
-func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-repo-user-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
 					"Jenkinsfile",
 					builder.RepoAuthSecret("repo-auth"),
@@ -151,10 +159,11 @@ fatal: could not read Username for 'https://github.com': No such device or addre
 }
 
 // PipelineRunWrongJenkinsfilePath is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile path
-func PipelineRunWrongJenkinsfilePath(Namespace string) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfilePath(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-path-", Namespace,
 			builder.PipelineRunSpec(
+				builder.Logging(name),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"not_existing_path/Jenkinsfile"),
 			)),


### PR DESCRIPTION
Add elastic search details to the pipeline runs of the integration tests.
This enables the logging to elastic search.