### PR TITLE
Improve runID in integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/go-containerregistry v0.0.0-20191115225042-f8574ec722f4 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/test/framework/client_creator.go
+++ b/test/framework/client_creator.go
@@ -38,5 +38,7 @@ func Setup(t *testing.T) context.Context {
 	ctx = SetNamespace(ctx, testClient)
 	ctx = SetTenantNamespace(ctx, tenantNamespace)
 	ctx = SetClientFactory(ctx, factory)
+	ctx = SetRealmUUID(ctx)
+	log.Printf("RealmUUID: %q", GetRealmUUID(ctx))
 	return ctx
 }

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	"github.com/SAP/stewardci-core/pkg/k8s"
+	"github.com/google/uuid"
 )
 
 type contextKey string
@@ -15,6 +16,7 @@ const (
 	namespaceKey       contextKey = "Namespace"
 	tenantNamespaceKey contextKey = "TenantNamespace"
 	testNameKey        contextKey = "testName"
+	realmUUIDKey       contextKey = "realmUUID"
 )
 
 // GetClientFactory returns the client factory from the context
@@ -69,4 +71,18 @@ func GetTestName(ctx context.Context) string {
 // SetTestName sets the test Name to the context
 func SetTestName(ctx context.Context, Name string) context.Context {
 	return context.WithValue(ctx, testNameKey, Name)
+}
+
+// GetRealmUUID returns an UUID for the test execution
+func GetRealmUUID(ctx context.Context) string {
+	val := ctx.Value(realmUUIDKey)
+	if val == nil {
+		return ""
+	}
+	return val.(string)
+}
+
+// SetRealmUUID returns an UUID for the test execution
+func SetRealmUUID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, realmUUIDKey, uuid.New().String())
 }

--- a/test/framework/context_test.go
+++ b/test/framework/context_test.go
@@ -45,3 +45,11 @@ func Test_Set_GetPipelineRun(t *testing.T) {
 	ctx = SetPipelineRun(ctx, run)
 	assert.DeepEqual(t, run, GetPipelineRun(ctx))
 }
+
+func Test_Set_GetRealmUUID(t *testing.T) {
+	ctx := context.Background()
+	assert.Equal(t, "", GetRealmUUID(ctx))
+
+	ctx = SetRealmUUID(ctx)
+	assert.Assert(t, GetRealmUUID(ctx) != "")
+}

--- a/test/framework/pipelineRun_helper.go
+++ b/test/framework/pipelineRun_helper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	"github.com/google/uuid"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,7 +39,12 @@ func executePipelineRunTests(ctx context.Context, t *testing.T, testPlans ...Tes
 			name :=
 				fmt.Sprintf("%s_%d", getTestPlanName(testPlan), i)
 			ctx = SetTestName(ctx, name)
-			runID := &api.CustomJSON{map[string]string{"buildId": name}}
+			runID := &api.CustomJSON{
+				map[string]string{
+					"jobId":    name,
+					"biuildId": uuid.New().String(),
+					"realmId":  GetRealmUUID(ctx),
+				}}
 
 			pipelineTest := testPlan.TestBuilder(tnn, runID)
 

--- a/test/framework/pipelineRun_helper.go
+++ b/test/framework/pipelineRun_helper.go
@@ -42,7 +42,7 @@ func executePipelineRunTests(ctx context.Context, t *testing.T, testPlans ...Tes
 			runID := &api.CustomJSON{
 				map[string]string{
 					"jobId":    name,
-					"biuildId": uuid.New().String(),
+					"buildId": uuid.New().String(),
 					"realmId":  GetRealmUUID(ctx),
 				}}
 

--- a/test/integrationtest/pipelineRun_testbuilders.go
+++ b/test/integrationtest/pipelineRun_testbuilders.go
@@ -24,11 +24,11 @@ var AllTestBuilders = []f.PipelineRunTestBuilder{
 const pipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
 
 // PipelineRunAbort is a PipelineRunTestBuilder to build a PipelineRunTest with aborted pipeline
-func PipelineRunAbort(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunAbort(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("sleep-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.Abort(),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"sleep/Jenkinsfile"),
@@ -40,11 +40,11 @@ func PipelineRunAbort(Namespace string, name *api.CustomJSON) f.PipelineRunTest 
 }
 
 // PipelineRunSleep is a PipelineRunTestBuilder to build PipelineRunTest which sleeps for one second
-func PipelineRunSleep(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunSleep(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("sleep-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"sleep/Jenkinsfile"),
 				builder.ArgSpec("SLEEP_FOR_SECONDS", "1"),
@@ -55,11 +55,11 @@ func PipelineRunSleep(Namespace string, name *api.CustomJSON) f.PipelineRunTest 
 }
 
 // PipelineRunFail is a PipelineRunTestBuilder to build PipelineRunTest which fails
-func PipelineRunFail(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunFail(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("error-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"error/Jenkinsfile"),
 			)),
@@ -69,11 +69,11 @@ func PipelineRunFail(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 }
 
 // PipelineRunOK is a PipelineRunTestBuilder to build PipelineRunTest which succeeds
-func PipelineRunOK(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunOK(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("ok-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"success/Jenkinsfile"),
 
@@ -85,11 +85,11 @@ func PipelineRunOK(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
 }
 
 // PipelineRunWithSecret is a PipelineRunTestBuilder to build PipelineRunTest which uses Secrets
-func PipelineRunWithSecret(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunWithSecret(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("with-secret-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"secret/Jenkinsfile"),
 				builder.ArgSpec("SECRETID", "with-secret-foo"),
@@ -104,11 +104,11 @@ func PipelineRunWithSecret(Namespace string, name *api.CustomJSON) f.PipelineRun
 }
 
 // PipelineRunMissingSecret is a PipelineRunTestBuilder to build PipelineRunTest which uses Secrets
-func PipelineRunMissingSecret(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunMissingSecret(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("missing-secret-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"secret/Jenkinsfile"),
 				builder.ArgSpec("SECRETID", "foo"),
@@ -122,11 +122,11 @@ func PipelineRunMissingSecret(Namespace string, name *api.CustomJSON) f.Pipeline
 }
 
 // PipelineRunWrongJenkinsfileRepo is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile repo url
-func PipelineRunWrongJenkinsfileRepo(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfileRepo(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-repo-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
 					"Jenkinsfile"),
 			)),
@@ -139,11 +139,11 @@ fatal: could not read Username for 'https://github.com': No such device or addre
 }
 
 // PipelineRunWrongJenkinsfileRepoWithUser is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile repo url
-func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-repo-user-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
 					"Jenkinsfile",
 					builder.RepoAuthSecret("repo-auth"),
@@ -159,11 +159,11 @@ fatal: could not read Username for 'https://github.com': No such device or addre
 }
 
 // PipelineRunWrongJenkinsfilePath is a PipelineRunTestBuilder to build PipelineRunTest with wrong jenkinsfile path
-func PipelineRunWrongJenkinsfilePath(Namespace string, name *api.CustomJSON) f.PipelineRunTest {
+func PipelineRunWrongJenkinsfilePath(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-path-", Namespace,
 			builder.PipelineRunSpec(
-				builder.Logging(name),
+				builder.Logging(runID),
 				builder.JenkinsFileSpec(pipelineRepoURL,
 					"not_existing_path/Jenkinsfile"),
 			)),


### PR DESCRIPTION
Improve runID details for the integration tests.
- change key of test name from buildId to jobId 
- add buildId for a single pipeline run
- add realmId for the complete test execution

