### PR TITLE
fix: chart: don't change PSP API group

### DIFF
--- a/charts/steward/templates/podsecuritypolicy-run.yaml
+++ b/charts/steward/templates/podsecuritypolicy-run.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: steward-run


### PR DESCRIPTION
When changing the API group of a PodSecurityPolicy resource object from
`extensions/v1beta1` to `policy/v1beta1`, the Helm upgrade from a
previous Helm chart version fails with:

```
Error: UPGRADE FAILED: rendered manifests contain a new resource that
already exists. Unable to continue with update: existing resource
conflict: namespace: , name: steward-run, existing_kind: policy/v1beta1,
Kind=PodSecurityPolicy, new_kind: policy/v1beta1, Kind=PodSecurityPolicy
```

Revert to API group `extensions/v1beta1`.