### PR TITLE
Fix codegen --verify

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -83,10 +83,15 @@ function generate_mocks() {
     { set +x; } 2>/dev/null
     if is_verify_mode; then
         set -x
-        diff -Naupr "${GEN_DIR}/${dest}" "${PROJECT_ROOT}/${dest}" || die "Regeneration required for mocks of '$pkg'"
+        diffIgnoreComments "${GEN_DIR}/${dest}" "${PROJECT_ROOT}/${dest}" || die "Regeneration required for mocks of '$pkg'"
         { set +x; } 2>/dev/null
     fi
     echo
+}
+
+function diffIgnoreComments() {
+    # Ignore go comments due to mockgen issue with generated '.' in comments
+    diff -Naupr <(cat "$1" | grep -v "^\/\/.*$") <(cat "$2" | grep -v "^\/\/.*$")
 }
 
 #


### PR DESCRIPTION
For some reason on some environments gomock generates
comment lines ending with a period, in other environments
without a period. Until we figured out what the reason is
this change excludes comment lines from the diff.