### PR TITLE
Fix mockgen issue with trailing dot

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -83,15 +83,10 @@ function generate_mocks() {
     { set +x; } 2>/dev/null
     if is_verify_mode; then
         set -x
-        diffIgnoreComments "${GEN_DIR}/${dest}" "${PROJECT_ROOT}/${dest}" || die "Regeneration required for mocks of '$pkg'"
+        diff -Naupr "${GEN_DIR}/${dest}" "${PROJECT_ROOT}/${dest}" || die "Regeneration required for mocks of '$pkg'"
         { set +x; } 2>/dev/null
     fi
     echo
-}
-
-function diffIgnoreComments() {
-    # Ignore go comments due to mockgen issue with generated '.' in comments
-    diff -Naupr <(cat "$1" | grep -v "^\/\/.*$") <(cat "$2" | grep -v "^\/\/.*$")
 }
 
 function checkGoVersion() {

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -119,6 +119,9 @@ if [[ -z $GOPATH ]]; then
 fi
 GOPATH_1=${GOPATH%%:*}  # the first entry of the GOPATH
 
+# Enable module mode to allow setting a version in 'go get'
+export GO111MODULE=on
+
 checkGoVersion
 
 # prepare code generator
@@ -132,7 +135,7 @@ checkGoVersion
 MOCKGEN_EXE="$GOPATH_1/bin/mockgen"
 if [[ ! -x $MOCKGEN_EXE ]]; then
     echo "Installing mockgen"
-    ( cd "$GOPATH_1" && go get github.com/golang/mock/mockgen ) || die "Installation of mockgen failed"
+    ( cd "$GOPATH_1" && go get github.com/golang/mock/mockgen@v1.4.3 ) || die "Installation of mockgen failed"
 fi
 [[ -f $MOCKGEN_EXE ]] || die "'$MOCKGEN_EXE' does not exist"
 [[ -x $MOCKGEN_EXE ]] || die "'$MOCKGEN_EXE' is not executable"
@@ -155,7 +158,8 @@ echo "CODEGEN_PKG:  $CODEGEN_PKG"
 echo "GOPATH:       $GOPATH_1"
 echo "VERIFY:       $(if is_verify_mode; then echo "true"; else echo "false"; fi)"
 echo "GO version:   $(go version)"
-
+echo "--- Environment with 'go': ---"
+env | grep -i "go"
 
 echo
 echo "## Cleanup old generated stuff ####################"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -114,9 +114,6 @@ if [[ -z $GOPATH ]]; then
 fi
 GOPATH_1=${GOPATH%%:*}  # the first entry of the GOPATH
 
-# Enable module mode to allow setting a version in 'go get'
-export GO111MODULE=on
-
 checkGoVersion
 
 # prepare code generator
@@ -130,7 +127,7 @@ checkGoVersion
 MOCKGEN_EXE="$GOPATH_1/bin/mockgen"
 if [[ ! -x $MOCKGEN_EXE ]]; then
     echo "Installing mockgen"
-    ( cd "$GOPATH_1" && go get github.com/golang/mock/mockgen@v1.4.3 ) || die "Installation of mockgen failed"
+    ( cd "$GOPATH_1" && GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.3 ) || die "Installation of mockgen failed"
 fi
 [[ -f $MOCKGEN_EXE ]] || die "'$MOCKGEN_EXE' does not exist"
 [[ -x $MOCKGEN_EXE ]] || die "'$MOCKGEN_EXE' is not executable"
@@ -153,8 +150,6 @@ echo "CODEGEN_PKG:  $CODEGEN_PKG"
 echo "GOPATH:       $GOPATH_1"
 echo "VERIFY:       $(if is_verify_mode; then echo "true"; else echo "false"; fi)"
 echo "GO version:   $(go version)"
-echo "--- Environment with 'go': ---"
-env | grep -i "go"
 
 echo
 echo "## Cleanup old generated stuff ####################"


### PR DESCRIPTION
The latest master version of mockgen generates the trailing periods. I have version v1.4.3 which does not generate them.

Without `GO111MODULE=on` `go get` will install the latest version from the master branch of a module. With, it is possible to specify the module release tag. This caused the issue of unexpected, different mock generations.