### PR TITLE
Remove apparmor profiles

### DIFF
--- a/charts/steward/templates/podsecuritypolicy-run.yaml
+++ b/charts/steward/templates/podsecuritypolicy-run.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     {{- include "steward.labels" . | nindent 4 }}
   annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:


### PR DESCRIPTION
apparmor is not supported on gardener cluster. These settings need to be removed, because otherwise pods are stuck in status: blocked.