### PR TITLE
JFR image with ES plugin v0.2.0

### DIFF
--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -73,7 +73,7 @@ pipelineRuns:
   jenkinsfileRunner:
     image:
       repository: stewardci/stewardci-jenkinsfile-runner
-      tag: "200408_e5e99d9"
+      tag: "200429_5649725"
       pullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
https://github.com/SAP/elasticsearch-logs-plugin/releases/tag/v0.2.0
This version switched to reading logs from local file system instead of Elasticsearch. Writing is still done to the configured Elasticsearch instance.