### PR TITLE
bootstrap-codegen: fetch latest tags of code-generator

### DIFF
--- a/hack/bootstrap-codegen.sh
+++ b/hack/bootstrap-codegen.sh
@@ -59,6 +59,7 @@ is_git_origin_url "$CODEGEN_GIT_URL" || die "\$CODEGEN_PKG ('${CODEGEN_PKG}'): u
 # (see https://github.com/kubernetes/code-generator#compatibility)
 git clean -dxf || die "failed to execute `git clean -dxf`"
 git reset --hard || die "failed to execute `git reset --hard`"
+git fetch origin --tags || die "failed to execute `git fetch origin --tags`"
 git checkout "kubernetes-$K8S_VERSION" || die "\$CODEGEN_PKG ('${CODEGEN_PKG}'): could not checkout revision kubernetes-$K8S_VERSION"
 if [[ ! -f "go.mod" ]]; then
     # this revision is not a Go module


### PR DESCRIPTION
If the local Git repository of code-generator is outdated, an upgrade to
a newer `K8S_VERSION` may result in an error when checking out the
respective tag.

This can be avoided by fetching tags from origin before.