### PR TITLE
add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/*
+!/go.mod
+!/go.sum
+!/cmd/
+!/pkg/


### PR DESCRIPTION
Dramatically reduce the build context size, especially when `gen` and
`temp` directories exist locally.