### PR TITLE
Add missing permissions for events

### DIFF
--- a/charts/steward/templates/clusterrole-run-controller.yaml
+++ b/charts/steward/templates/clusterrole-run-controller.yaml
@@ -25,7 +25,7 @@ rules:
   resources: ["taskruns"]
   verbs: ["create","delete","get","list","patch","update","watch"]
 - apiGroups: [""]
-  resources: ["namespaces","secrets","resourcequotas","limitranges"]
+  resources: ["namespaces","secrets","resourcequotas","limitranges","events"]
   verbs: ["create","delete","get","list","patch","update","watch"]
 ## may be restricted to steward-system namespace???
 - apiGroups: [""]

--- a/charts/steward/templates/clusterrole-run.yaml
+++ b/charts/steward/templates/clusterrole-run.yaml
@@ -15,7 +15,7 @@ rules:
   resources: ["pods/log"]
   verbs: ["get","list","watch"]
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets","events"]
   verbs: ["get","list","watch"]
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']


### PR DESCRIPTION
Run controller needs permissions to read/write/edit events.
The service account in the run-namespace needs permissions to watch events. 