### PR TITLE
adjust run controller resources

### DIFF
--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -13,9 +13,9 @@ runController:
   resources:
     limits:
       cpu: 1
-      memory: 64Mi
+      memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 100m
   podSecurityContext: {}
     # fsGroup: 2000
   securityContext:


### PR DESCRIPTION
During load tests the pipeline run controller was OOM-killed. Also, CPU utilization was constantly at around 50m.

Increase the memory to 128Mi and CPU requests to 100m.