### PR TITLE
Make qps and burst configurable to avoid long waiting times

### DIFF
--- a/charts/steward/README.md
+++ b/charts/steward/README.md
@@ -107,8 +107,8 @@ Pipeline Run Controller:
 | <code>runController.<wbr/>nodeSelector</code> | (object)<br/> The `nodeSelector` field of the Run Controller [pod spec][k8s-podspec]. | `{}` |
 | <code>runController.<wbr/>affinity</code> | (object of [`Affinity`][k8s-affinity])<br/> The `affinity` field of the Run Controller [pod spec][k8s-podspec]. | `{}` |
 | <code>runController.<wbr/>tolerations</code> | (array of [`Toleration`][k8s-tolerations])<br/> The `tolerations` field of the Run Controller [pod spec][k8s-podspec]. | `[]` |
-| <code>runController.<wbr/>args.<wbr/>qps</code> | (integer)<br/> The maximum QPS from the controller to the cluster. | 5 |
-| <code>runController.<wbr/>args.<wbr/>burst</code> | (integer)<br/> The burst for trottle connections. | 10 |
+| <code>runController.<wbr/>args.<wbr/>qps</code> | (integer)<br/> The maximum queries per second (QPS) from the controller to the cluster. | 5 |
+| <code>runController.<wbr/>args.<wbr/>burst</code> | (integer)<br/> The burst limit for throttle connections (maximum number of concurrent requests). | 10 |
 
 Tenant Controller:
 

--- a/charts/steward/README.md
+++ b/charts/steward/README.md
@@ -107,6 +107,8 @@ Pipeline Run Controller:
 | <code>runController.<wbr/>nodeSelector</code> | (object)<br/> The `nodeSelector` field of the Run Controller [pod spec][k8s-podspec]. | `{}` |
 | <code>runController.<wbr/>affinity</code> | (object of [`Affinity`][k8s-affinity])<br/> The `affinity` field of the Run Controller [pod spec][k8s-podspec]. | `{}` |
 | <code>runController.<wbr/>tolerations</code> | (array of [`Toleration`][k8s-tolerations])<br/> The `tolerations` field of the Run Controller [pod spec][k8s-podspec]. | `[]` |
+| <code>runController.<wbr/>args.<wbr/>qps</code> | (integer)<br/> The maximum QPS from the controller to the cluster. | 5 |
+| <code>runController.<wbr/>args.<wbr/>burst</code> | (integer)<br/> The burst for trottle connections. | 10 |
 
 Tenant Controller:
 

--- a/charts/steward/templates/deployment-run-controller.yaml
+++ b/charts/steward/templates/deployment-run-controller.yaml
@@ -33,6 +33,10 @@ spec:
         image: {{ printf "%s:%s" .repository .tag | quote }}
         imagePullPolicy: {{ .pullPolicy | quote }}
         {{- end }}
+        args:
+        - -qps={{ .Values.runController.args.qps }}
+        - -burst={{ .Values.runController.args.burst }}
+    command:
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/charts/steward/templates/deployment-run-controller.yaml
+++ b/charts/steward/templates/deployment-run-controller.yaml
@@ -36,7 +36,8 @@ spec:
         args:
         - -qps={{ .Values.runController.args.qps }}
         - -burst={{ .Values.runController.args.burst }}
-    command:
+        command:
+        - /app/main
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -6,6 +6,9 @@ targetNamespace:
   name: "steward-system"
 
 runController:
+  args:
+    qps: 5
+    burst: 10
   image:
     repository: stewardci/stewardci-run-controller
     tag: "0.4.7" #Do not modify this line! RunController tag updated automatically

--- a/cmd/run_controller/main.go
+++ b/cmd/run_controller/main.go
@@ -53,6 +53,8 @@ func main() {
 	system.Namespace() // ensure that namespace is set in environment
 
 	log.Printf("Create Factory (resync period: %s)", resyncPeriod.String())
+	config.QPS = 500
+	config.Burst = 1000
 	factory := k8s.NewClientFactory(config, resyncPeriod)
 
 	log.Printf("Provide metrics")

--- a/cmd/run_controller/main.go
+++ b/cmd/run_controller/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 var kubeconfig string
+var burst, qps int
 
 // Time to wait until the next resync takes place.
 // Resync is only required if events got lost or if the controller restarted (and missed events).
@@ -23,7 +24,8 @@ const resyncPeriod = 30 * time.Second
 
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
-
+	flag.IntVar(&burst, "burst", 200, "burst for RESTClient")
+	flag.IntVar(&qps, "qps", 100, "QPS for RESTClient")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to Kubernetes config file")
 	flag.Parse()
 }
@@ -52,9 +54,9 @@ func main() {
 
 	system.Namespace() // ensure that namespace is set in environment
 
-	log.Printf("Create Factory (resync period: %s)", resyncPeriod.String())
-	config.QPS = 500
-	config.Burst = 1000
+	log.Printf("Create Factory (resync period: %s, QPS: %d, burst: %d)", resyncPeriod.String(), qps, burst)
+	config.QPS = float32(qps)
+	config.Burst = burst
 	factory := k8s.NewClientFactory(config, resyncPeriod)
 
 	log.Printf("Provide metrics")

--- a/cmd/run_controller/main.go
+++ b/cmd/run_controller/main.go
@@ -24,8 +24,8 @@ const resyncPeriod = 30 * time.Second
 
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
-	flag.IntVar(&burst, "burst", 200, "burst for RESTClient")
-	flag.IntVar(&qps, "qps", 100, "QPS for RESTClient")
+	flag.IntVar(&burst, "burst", 10, "burst for RESTClient")
+	flag.IntVar(&qps, "qps", 5, "QPS for RESTClient")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to Kubernetes config file")
 	flag.Parse()
 }

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -18,6 +18,8 @@ There is also an [example dashboard][example-dashboard] for [Grafana] available 
 | `steward_pipelineruns_started_total`   | counter   | _none_ | counter is increased by every started pipeline run |
 | `steward_pipelineruns_completed_total` | counter   | result | counters with result label are increased when result of pipeline run is set |
 | `steward_pipelinerun_duration_seconds` | histogram | state  | histogram with 15 exponential buckets starting from 125ms with factor 2 for the different pipelinerun states |
+| `steward_pipelinerun_update_seconds`   | histogram | state  | histogram with 30 exponential buckets starting from 1 ms with factor 1.3 for a pipelinerun update |
+| `steward_queued_total`                 | gauge     | _none_ | number of pipelineruns waiting in the queue to be processed by the controller |
 
 ## Example Installation with Prometheus Operator
 

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -302,7 +302,7 @@ func (r *pipelineRun) changeStatusAndUpdateSafely(change func()) error {
 	end := time.Now()
 	elapsed := end.Sub(start)
 	if r.apiObj != nil {
-		log.Printf("finish update after %d iteration %s in %s", iteration, elapsed, r.apiObj.Name)
+		log.Printf("finished update after %s (with %d retries) in %s", elapsed, iteration, r.apiObj.Name)
 	}
 
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -58,7 +58,7 @@ func NewMetrics() Metrics {
 		Update: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "steward_pipelinerun_update_seconds",
 			Help:    "pipeline run update duration",
-			Buckets: prometheus.ExponentialBuckets(0.001, 1.3, 20),
+			Buckets: prometheus.ExponentialBuckets(0.001, 1.3, 30),
 		},
 			[]string{"state"}),
 		Total: prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -58,7 +58,7 @@ func NewMetrics() Metrics {
 		Update: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "steward_pipelinerun_update_seconds",
 			Help:    "pipeline run update duration",
-			Buckets: prometheus.ExponentialBuckets(0.0125, 2, 15),
+			Buckets: prometheus.ExponentialBuckets(0.001, 1.3, 20),
 		},
 			[]string{"state"}),
 		Total: prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,13 +18,19 @@ type Metrics interface {
 	CountStart()
 	CountResult(api.Result)
 	ObserveDurationByState(state *api.StateItem) error
+	ObserveUpdateDurationByType(kind string, duration time.Duration)
 	StartServer()
+	SetQueueCount(int)
+	//SetTotalCount(int)
 }
 
 type metrics struct {
 	Started   prometheus.Counter
 	Completed *prometheus.CounterVec
 	Duration  *prometheus.HistogramVec
+	Update    *prometheus.HistogramVec
+	Queued    prometheus.Gauge
+	Total     prometheus.Gauge
 }
 
 // NewMetrics create metrics
@@ -44,6 +51,20 @@ func NewMetrics() Metrics {
 			Buckets: prometheus.ExponentialBuckets(0.125, 2, 15),
 		},
 			[]string{"state"}),
+		Queued: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "steward_queued_total",
+			Help: "total queue count of pipelineruns",
+		}),
+		Update: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "steward_pipelinerun_update_seconds",
+			Help:    "pipeline run update duration",
+			Buckets: prometheus.ExponentialBuckets(0.0125, 2, 15),
+		},
+			[]string{"state"}),
+		Total: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "steward_pipelineruns_total",
+			Help: "total number of pipelineruns",
+		}),
 	}
 }
 
@@ -84,4 +105,18 @@ func (metrics *metrics) ObserveDurationByState(state *api.StateItem) error {
 	}
 	metrics.Duration.With(prometheus.Labels{"state": string(state.State)}).Observe(duration.Seconds())
 	return nil
+}
+
+func (metrics *metrics) ObserveUpdateDurationByType(kind string, duration time.Duration) {
+	metrics.Update.With(prometheus.Labels{"state": kind}).Observe(duration.Seconds())
+}
+
+// SetQueueCount logs queue count metric
+func (metrics *metrics) SetQueueCount(count int) {
+	metrics.Queued.Set(float64(count))
+}
+
+// SetTotalCount logs total number of pipelineruns
+func (metrics *metrics) SetTotalCount(count int) {
+	metrics.Total.Set(float64(count))
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,7 +60,7 @@ func NewMetrics() Metrics {
 			Help:    "pipeline run update duration",
 			Buckets: prometheus.ExponentialBuckets(0.001, 1.3, 30),
 		},
-			[]string{"state"}),
+			[]string{"type"}),
 		Total: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "steward_pipelineruns_total",
 			Help: "total number of pipelineruns",
@@ -109,8 +109,8 @@ func (metrics *metrics) ObserveDurationByState(state *api.StateItem) error {
 	return nil
 }
 
-func (metrics *metrics) ObserveUpdateDurationByType(kind string, duration time.Duration) {
-	metrics.Update.With(prometheus.Labels{"state": kind}).Observe(duration.Seconds())
+func (metrics *metrics) ObserveUpdateDurationByType(typ string, duration time.Duration) {
+	metrics.Update.With(prometheus.Labels{"type": typ}).Observe(duration.Seconds())
 }
 
 // SetQueueCount logs queue count metric

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,6 +73,8 @@ func (metrics *metrics) StartServer() {
 	prometheus.MustRegister(metrics.Started)
 	prometheus.MustRegister(metrics.Completed)
 	prometheus.MustRegister(metrics.Duration)
+	prometheus.MustRegister(metrics.Update)
+	prometheus.MustRegister(metrics.Queued)
 	go provideMetrics()
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,7 +21,6 @@ type Metrics interface {
 	ObserveUpdateDurationByType(kind string, duration time.Duration)
 	StartServer()
 	SetQueueCount(int)
-	//SetTotalCount(int)
 }
 
 type metrics struct {
@@ -116,9 +115,4 @@ func (metrics *metrics) ObserveUpdateDurationByType(typ string, duration time.Du
 // SetQueueCount logs queue count metric
 func (metrics *metrics) SetQueueCount(count int) {
 	metrics.Queued.Set(float64(count))
-}
-
-// SetTotalCount logs total number of pipelineruns
-func (metrics *metrics) SetTotalCount(count int) {
-	metrics.Total.Set(float64(count))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -26,6 +26,11 @@ func Test_Duration_End_Before_Beginning(t *testing.T) {
 	assert.Equal(t, "cannot observe StateItem if FinishedAt is before StartedAt", e.Error())
 }
 
+func Test_ObserveUpdateDurationByType(t *testing.T) {
+	m := NewMetrics()
+	m.ObserveUpdateDurationByType("foo", 1)
+}
+
 func fakeStateItem(state api.State, duration time.Duration) *api.StateItem {
 	startTime := metav1.Now()
 	endTime := metav1.NewTime(startTime.Time.Add(duration))

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -11,6 +11,7 @@ import (
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	"github.com/SAP/stewardci-core/pkg/client/clientset/versioned/scheme"
+	"github.com/SAP/stewardci-core/pkg/client/listers/steward/v1alpha1"
 	"github.com/SAP/stewardci-core/pkg/k8s"
 	"github.com/SAP/stewardci-core/pkg/k8s/secrets"
 	"github.com/SAP/stewardci-core/pkg/metrics"
@@ -38,6 +39,7 @@ type Controller struct {
 	metrics              metrics.Metrics
 	testing              *controllerTesting
 	recorder             record.EventRecorder
+	pipelineRunLister    v1alpha1.PipelineRunLister
 }
 
 type controllerTesting struct {
@@ -48,6 +50,7 @@ type controllerTesting struct {
 // NewController creates new Controller
 func NewController(factory k8s.ClientFactory, metrics metrics.Metrics) *Controller {
 	pipelineRunInformer := factory.StewardInformerFactory().Steward().V1alpha1().PipelineRuns()
+	pipelineRunLister := pipelineRunInformer.Lister()
 	pipelineRunFetcher := k8s.NewListerBasedPipelineRunFetcher(pipelineRunInformer.Lister())
 	tektonTaskRunInformer := factory.TektonInformerFactory().Tekton().V1alpha1().TaskRuns()
 	eventBroadcaster := record.NewBroadcaster()
@@ -58,6 +61,7 @@ func NewController(factory k8s.ClientFactory, metrics metrics.Metrics) *Controll
 	controller := &Controller{
 		factory:            factory,
 		pipelineRunFetcher: pipelineRunFetcher,
+		pipelineRunLister:  pipelineRunLister,
 		pipelineRunSynced:  pipelineRunInformer.Informer().HasSynced,
 
 		tektonTaskRunsSynced: tektonTaskRunInformer.Informer().HasSynced,
@@ -137,6 +141,15 @@ func (c *Controller) processNextWorkItem() bool {
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Foo resource to be synced.
+		log.Printf("process %s queue length: %d", key, c.workqueue.Len())
+		c.metrics.SetQueueCount(c.workqueue.Len())
+
+		/*allPipelineruns, err := c.pipelineRunLister.List(labels.Everything())
+		if err == nil {
+			log.Printf("total pipelineruns: %d", len(allPipelineruns))
+			c.metrics.SetTotalCount(len(allPipelineruns))
+		}*/
+
 		if err := c.syncHandler(key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(key)
@@ -158,11 +171,17 @@ func (c *Controller) processNextWorkItem() bool {
 }
 
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
+	start := time.Now()
 	oldState, err := pipelineRun.UpdateState(state)
 	if err != nil {
 		log.Printf("Failed to UpdateState of [%s] to %q: %q", pipelineRun.String(), state, err.Error())
 		return err
 	}
+
+	end := time.Now()
+	elapsed := end.Sub(start)
+	c.metrics.ObserveUpdateDurationByType("UpdateState", elapsed)
+
 	if oldState != nil {
 		err := c.metrics.ObserveDurationByState(oldState)
 		if err != nil {
@@ -283,7 +302,9 @@ func (c *Controller) syncHandler(key string) error {
 			return err
 		}
 	case api.StateWaiting:
+		log.Printf("state waiting %s", pipelineRun.GetName())
 		run, err := runManager.GetRun(pipelineRun)
+		log.Printf("get done %s", pipelineRun.GetName())
 		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonWaitingFailed, err.Error())
 			if IsRecoverable(err) {
@@ -298,11 +319,13 @@ func (c *Controller) syncHandler(key string) error {
 			return nil
 		}
 		started := run.GetStartTime()
+		log.Printf("found start time %s for %s", started, pipelineRun.GetName())
 		if started != nil {
 			if err = c.changeState(pipelineRun, api.StateRunning); err != nil {
 				return err
 			}
 		}
+		log.Printf("state changed %s", pipelineRun.GetName())
 	case api.StateRunning:
 		run, err := runManager.GetRun(pipelineRun)
 		if err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -144,12 +144,6 @@ func (c *Controller) processNextWorkItem() bool {
 		log.Printf("process %s queue length: %d", key, c.workqueue.Len())
 		c.metrics.SetQueueCount(c.workqueue.Len())
 
-		/*allPipelineruns, err := c.pipelineRunLister.List(labels.Everything())
-		if err == nil {
-			log.Printf("total pipelineruns: %d", len(allPipelineruns))
-			c.metrics.SetTotalCount(len(allPipelineruns))
-		}*/
-
 		if err := c.syncHandler(key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(key)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -302,9 +302,7 @@ func (c *Controller) syncHandler(key string) error {
 			return err
 		}
 	case api.StateWaiting:
-		log.Printf("state waiting %s", pipelineRun.GetName())
 		run, err := runManager.GetRun(pipelineRun)
-		log.Printf("get done %s", pipelineRun.GetName())
 		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonWaitingFailed, err.Error())
 			if IsRecoverable(err) {
@@ -319,13 +317,11 @@ func (c *Controller) syncHandler(key string) error {
 			return nil
 		}
 		started := run.GetStartTime()
-		log.Printf("found start time %s for %s", started, pipelineRun.GetName())
 		if started != nil {
 			if err = c.changeState(pipelineRun, api.StateRunning); err != nil {
 				return err
 			}
 		}
-		log.Printf("state changed %s", pipelineRun.GetName())
 	case api.StateRunning:
 		run, err := runManager.GetRun(pipelineRun)
 		if err != nil {


### PR DESCRIPTION
This change contains:
- 2 additional metrics
  - to monitor the update times of pipeline-runs
  - to monitor the queue length of the pipeline run controller
- 2 additional parameters to the run controller to set qps and burst limits

The helm chart is adjusted to be able to configure qps and burst limits for the run controller.