### PR TITLE
Reduce run controller logging

### DIFF
--- a/charts/steward/README.md
+++ b/charts/steward/README.md
@@ -109,6 +109,7 @@ Pipeline Run Controller:
 | <code>runController.<wbr/>tolerations</code> | (array of [`Toleration`][k8s-tolerations])<br/> The `tolerations` field of the Run Controller [pod spec][k8s-podspec]. | `[]` |
 | <code>runController.<wbr/>args.<wbr/>qps</code> | (integer)<br/> The maximum queries per second (QPS) from the controller to the cluster. | 5 |
 | <code>runController.<wbr/>args.<wbr/>burst</code> | (integer)<br/> The burst limit for throttle connections (maximum number of concurrent requests). | 10 |
+| <code>runController.<wbr/>args.<wbr/>logVerbosity</code> | (integer)<br/> The log verbosity. 0=error, 1=warning, 2=info, 3=extended, 4=debug, 5=trace (see also [logging-conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#logging-conventions)) | 3 |
 
 Tenant Controller:
 

--- a/charts/steward/templates/deployment-run-controller.yaml
+++ b/charts/steward/templates/deployment-run-controller.yaml
@@ -33,9 +33,12 @@ spec:
         image: {{ printf "%s:%s" .repository .tag | quote }}
         imagePullPolicy: {{ .pullPolicy | quote }}
         {{- end }}
-        args:
-        - -qps={{ .Values.runController.args.qps }}
-        - -burst={{ .Values.runController.args.burst }}
+        args: [
+        "-qps={{ .Values.runController.args.qps }}",
+        "-burst={{ .Values.runController.args.burst }}",
+        {{- if .Values.runController.args.logVerbosity }}
+        "-v", {{ .Values.runController.args.logVerbosity | quote }},
+        {{- end }}
         command:
         - /app/main
         env:

--- a/charts/steward/templates/deployment-run-controller.yaml
+++ b/charts/steward/templates/deployment-run-controller.yaml
@@ -39,6 +39,7 @@ spec:
         {{- if .Values.runController.args.logVerbosity }}
         "-v", {{ .Values.runController.args.logVerbosity | quote }},
         {{- end }}
+        ]
         command:
         - /app/main
         env:

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -9,6 +9,7 @@ runController:
   args:
     qps: 5
     burst: 10
+    logVerbosity: 3
   image:
     repository: stewardci/stewardci-run-controller
     tag: "0.4.12" #Do not modify this line! RunController tag updated automatically

--- a/cmd/run_controller/main.go
+++ b/cmd/run_controller/main.go
@@ -12,6 +12,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	klog "k8s.io/klog/v2"
 	"knative.dev/pkg/system"
 )
 
@@ -23,6 +24,7 @@ var burst, qps int
 const resyncPeriod = 30 * time.Second
 
 func init() {
+	klog.InitFlags(nil)
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
 	flag.IntVar(&burst, "burst", 10, "burst for RESTClient")
 	flag.IntVar(&qps, "qps", 5, "QPS for RESTClient")

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
-	k8s.io/klog/v2 v2.1.0 // indirect
+	k8s.io/klog/v2 v2.1.0
 	k8s.io/legacy-cloud-providers v0.18.3 // indirect
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 // indirect
 	knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -34,8 +34,8 @@ const kind = "PipelineRuns"
 var finishedRuns sync.Map
 
 // Used for logging (control loop) "still alive" messages
-var aliveIntervalSeconds int64 = 60
-var aliveTimer int64 = 0
+var heartbeatIntervalSeconds int64 = 60
+var heartbeatTimer int64 = 0
 
 // Controller processes PipelineRun resources
 type Controller struct {
@@ -113,8 +113,8 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 func (c *Controller) runWorker() {
 	for c.processNextWorkItem() {
 		now := time.Now().Unix()
-		if aliveTimer <= now - aliveIntervalSeconds {
-			aliveTimer = now
+		if heartbeatTimer <= now - heartbeatIntervalSeconds {
+			heartbeatTimer = now
 			log.Printf("Run Controller still alive")
 		}
 	}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -109,7 +109,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 func (c *Controller) runWorker() {
 	for c.processNextWorkItem() {
 		now := time.Now().Unix()
-		if heartbeatTimer <= now - heartbeatIntervalSeconds {
+		if heartbeatTimer <= now-heartbeatIntervalSeconds {
 			heartbeatTimer = now
 			klog.V(3).Infof("Run Controller still alive")
 		}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -30,7 +30,11 @@ import (
 
 const kind = "PipelineRuns"
 
+// Map with keys of finished PipelineRuns, e.g. to avoid unnecessary logging.
 var finishedRuns sync.Map
+
+// Used for logging (control loop) "still alive" messages
+var aliveIntervalSeconds int64 = 60
 var aliveTimer int64 = 0
 
 // Controller processes PipelineRun resources
@@ -109,7 +113,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 func (c *Controller) runWorker() {
 	for c.processNextWorkItem() {
 		now := time.Now().Unix()
-		if aliveTimer <= now - 30 {
+		if aliveTimer <= now - aliveIntervalSeconds {
 			aliveTimer = now
 			log.Printf("Run Controller still alive")
 		}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	klog "k8s.io/klog/v2"
 )
 
 const kind = "PipelineRuns"
@@ -154,9 +155,11 @@ func (c *Controller) processNextWorkItem() bool {
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Foo resource to be synced.
-		if _, finished := finishedRuns.Load(key); !finished {
-			log.Printf("process %s queue length: %d", key, c.workqueue.Len())
+		verbosity := klog.Level(2)
+		if _, finished := finishedRuns.Load(key); finished {
+			verbosity = klog.Level(4)
 		}
+		klog.V(verbosity).Infof("[v%d]process %s queue length: %d", verbosity, key, c.workqueue.Len())
 		c.metrics.SetQueueCount(c.workqueue.Len())
 
 		if err := c.syncHandler(key); err != nil {


### PR DESCRIPTION
Since also every finished PipelineRun is "processed" by the Run Controller this produces 3 unnecessary log entries per PipelineRun, every 30 seconds. This will let the logs explode.