### PR TITLE
Fix broken hyperlink

### DIFF
--- a/docs/testing/PermissionTests.md
+++ b/docs/testing/PermissionTests.md
@@ -1,6 +1,6 @@
 # How to test permissions
 
-Prerequisites: steward-system and a steward-client called `steward-client-1` [prepared](README.md).
+Prerequisites: steward-system and a steward-client called `steward-client-1` prepared.
 
 ## Test `client namespace` with `client service account`
 

--- a/docs/testing/PermissionTests.md
+++ b/docs/testing/PermissionTests.md
@@ -1,6 +1,6 @@
 # How to test permissions
 
-Prerequisites: steward-system and a steward-client called `steward-client-1` prepared.
+Prerequisites: steward-system and a steward-client called `steward-client-1` [prepared](../../backend-k8s/steward-client-example).
 
 ## Test `client namespace` with `client service account`
 


### PR DESCRIPTION
The content in docs/testing/PermissionTests.md was pointing to non-existing README.md.