### PR TITLE
fix tenant controller

### DIFF
--- a/charts/steward/templates/deployment-tenant-controller.yaml
+++ b/charts/steward/templates/deployment-tenant-controller.yaml
@@ -37,6 +37,8 @@ spec:
         {{- if .Values.tenantController.args.logVerbosity }}
         - {{ printf "-v=%d" ( .Values.tenantController.args.logVerbosity | int ) | quote }}
         {{- end }}
+        command:
+        - /app/main
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Last version a argument was added to tenant controller, but the command was not specified, which leads to the error: `Error: failed to start container "controller": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"-v=2\": executable file not found in $PATH": unknown`