### PR TITLE
Fix: ClusterTask does not comply with schema

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -17,8 +17,19 @@
 - version: "NEXT"
   date: TBD
   
+- version: "0.5.1"
+  date: 2020-10-05
+  changes:
+  - type: bug
+    impact: patch
+    title: Fix clustertask
+
+    description: >-
+      Fix clustertask to match v1beta1 specification.
+    pullRequestNumber: 163
+
 - version: "0.5.0"
-  date: 29/09/2020
+  date: 2020-08-29
   changes:
   - type: enhancement
     impact: incompatible

--- a/charts/steward/templates/clustertask-jenkinsfile-runner.yaml
+++ b/charts/steward/templates/clustertask-jenkinsfile-runner.yaml
@@ -6,71 +6,70 @@ metadata:
     {{- include "steward.labels" . | nindent 4 }}
     {{- include "steward.runController.componentLabel" . | nindent 4 }}
 spec:
-  inputs:
-    params:
-    - name: PIPELINE_PARAMS_JSON
-      type: string
-      description: >
-        Parameters to pass to the pipeline, as JSON string.
-    - name: PIPELINE_GIT_URL
-      type: string
-      description: >
-        The URL of the Git repository containing the pipeline definition.
-    - name: PIPELINE_GIT_REVISION
-      type: string
-      description: >
-        The revision of the pipeline Git repository to used, e.g. 'master'.
-    - name: PIPELINE_FILE
-      type: string
-      description: >
-        The relative pathname of the pipeline definition file, typically 'Jenkinsfile'.
-    - name: PIPELINE_LOG_ELASTICSEARCH_INDEX_URL
-      type: string
-      description: >
-        The URL of the Elasticsearch index to send logs to.
-        If null or empty, logging to Elasticsearch is disabled.
-        # Example: http://elasticsearch-master.elasticsearch.svc.cluster.local:9200/jenkins-logs/_doc
-      default: {{ default "" .Values.pipelineRuns.logging.elasticsearch.indexURL | quote }}
-    - name: PIPELINE_LOG_ELASTICSEARCH_AUTH_SECRET
-      type: string
-      description: >
-        The name of the secret of type basic-auth to use to authenticate to Elasticsearch.
-        If null or empty, no authentication takes place.
-      default: ""
-    - name: PIPELINE_LOG_ELASTICSEARCH_TRUSTEDCERTS_SECRET
-      type: string
-      description: >
-        The name of the secret providing the trusted certificates bundle used for TLS server verification when connecting to Elasticsearch.
-        If null or empty, the default trusted certificates are used.
-      default: ""
-    - name: PIPELINE_LOG_ELASTICSEARCH_RUN_ID_JSON
-      type: string
-      description: >
-        The value for the 'runId' field of log events, as JSON string.
-        Must be specified if logging to Elasticsearch is enabled.
-      default: ""
-    - name: RUN_NAMESPACE
-      type: string
-      description: >
-        The namespace of this pipeline run.
-    - name: JOB_NAME
-      type: string
-      description: >
-        The name of the job this pipeline run belongs to. It is used as the name of the Jenkins job and therefore must be a valid Jenkins job name.
-        If null or empty, `job` will be used.
-      default: ""
-    - name: RUN_NUMBER
-      type: string
-      description: >
-        The sequence number of the pipeline run, which translates into the build number of the Jenkins job.
-        If null or empty, `1` is used.
-      default: "1"
-    - name: RUN_CAUSE
-      type: string
-      description: >
-        A textual description of the cause of this pipeline run. Will be set as cause of the Jenkins job.
-        If null or empty, no cause information will be available.
-      default: ""
+  params:
+  - name: PIPELINE_PARAMS_JSON
+    type: string
+    description: >
+      Parameters to pass to the pipeline, as JSON string.
+  - name: PIPELINE_GIT_URL
+    type: string
+    description: >
+      The URL of the Git repository containing the pipeline definition.
+  - name: PIPELINE_GIT_REVISION
+    type: string
+    description: >
+      The revision of the pipeline Git repository to used, e.g. 'master'.
+  - name: PIPELINE_FILE
+    type: string
+    description: >
+      The relative pathname of the pipeline definition file, typically 'Jenkinsfile'.
+  - name: PIPELINE_LOG_ELASTICSEARCH_INDEX_URL
+    type: string
+    description: >
+      The URL of the Elasticsearch index to send logs to.
+      If null or empty, logging to Elasticsearch is disabled.
+      # Example: http://elasticsearch-master.elasticsearch.svc.cluster.local:9200/jenkins-logs/_doc
+    default: {{ default "" .Values.pipelineRuns.logging.elasticsearch.indexURL | quote }}
+  - name: PIPELINE_LOG_ELASTICSEARCH_AUTH_SECRET
+    type: string
+    description: >
+      The name of the secret of type basic-auth to use to authenticate to Elasticsearch.
+      If null or empty, no authentication takes place.
+    default: ""
+  - name: PIPELINE_LOG_ELASTICSEARCH_TRUSTEDCERTS_SECRET
+    type: string
+    description: >
+      The name of the secret providing the trusted certificates bundle used for TLS server verification when connecting to Elasticsearch.
+      If null or empty, the default trusted certificates are used.
+    default: ""
+  - name: PIPELINE_LOG_ELASTICSEARCH_RUN_ID_JSON
+    type: string
+    description: >
+      The value for the 'runId' field of log events, as JSON string.
+      Must be specified if logging to Elasticsearch is enabled.
+    default: ""
+  - name: RUN_NAMESPACE
+    type: string
+    description: >
+      The namespace of this pipeline run.
+  - name: JOB_NAME
+    type: string
+    description: >
+      The name of the job this pipeline run belongs to. It is used as the name of the Jenkins job and therefore must be a valid Jenkins job name.
+      If null or empty, `job` will be used.
+    default: ""
+  - name: RUN_NUMBER
+    type: string
+    description: >
+      The sequence number of the pipeline run, which translates into the build number of the Jenkins job.
+      If null or empty, `1` is used.
+    default: "1"
+  - name: RUN_CAUSE
+    type: string
+    description: >
+      A textual description of the cause of this pipeline run. Will be set as cause of the Jenkins job.
+      If null or empty, no cause information will be available.
+    default: ""
   steps:
   - name: jenkinsfile-runner
     {{- with .Values.pipelineRuns.jenkinsfileRunner.image }}


### PR DESCRIPTION
With the upgrade of the Tekton ClusterTask custom resource from v1alpha1 to v1beta1 the `params` field is no longer a child of `inputs` but resides directly under `spec`. This change adapts Steward's ClusterTask `jenkinsfile-runner` accordingly.

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] with upgrade notes are prepared and appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
  - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

No changes in dependencies.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] 'Upgrade notes' are documented in changelog.yaml (if required)
- [x] [changelog.yaml] entry for this Pull Request has been added
  - [x] Changelog entry contains all required information

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
