### PR TITLE
Improved comments in changelog.yaml

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -14,7 +14,8 @@
 #      jiraIssueNumber: <Internal Jira issue number>
 
 
-# Do not change the "NEXT" version block
+# Do not modify the "NEXT" version block.
+# Do not change the order ("NEXT" needs to be on top).
 - version: "NEXT"
   date: TBD
   

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -11,9 +11,10 @@
 #      upgradeNotes: >-
 #        <optional upgrade guidelines>
 #      pullRequestNumber: <pull request number>
-
 #      jiraIssueNumber: <Internal Jira issue number>
 
+
+# Do not change the "NEXT" version block
 - version: "NEXT"
   date: TBD
   


### PR DESCRIPTION
<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
Add some helpful comments to the changelog.yaml


### Dependency release notes

<!-- add links to release notes if important dependencies changed -->
N/A

### Submitter checklist

Trivial change. No changelog entry necessary.

- [ ] Change has been tested (on a back-end cluster)
- [ ] N/A [changelog.yaml] with upgrade notes are prepared and appropriate for the audience affected by the change (users or developer, depending on the change).
- [ ] N/A Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
  - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] N/A Links to external changelogs added since the last release of our component
- [ ] N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] N/A Check if dependency update affects our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [ ] N/A 'Upgrade notes' are documented in changelog.yaml (if required)
- [ ] N/A [changelog.yaml] entry for this Pull Request has been added
  - [ ] N/A Changelog entry contains all required information

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
