### PR TITLE
Introduce auxiliary pipeline run namespaces

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,22 @@
   date: TBD
   changes:
 
+  - title: Introduce auxiliary pipeline run namespaces
+    type: enhancement
+    impact: patch
+    description: |-
+      In the future Steward will be enabled to provision service instances
+      per pipeline run, e.g. a pipeline log forwarder.
+      This change introduces auxiliary pipeline run namespaces where
+      those run-specific service instances are defined in Kubernetes.
+
+      The pattern of pipeline run namespace names changes.
+
+      By default auxiliary namespaces are not created because they are not
+      used yet. Enabling the feature flag `CreateAuxNamespaceIfUnused`
+      enforces creating auxiliary namespaces.
+    pullRequestNumber: 168
+
 - version: "0.8.2"
   date: 2021-03-05
   changes:
@@ -66,7 +82,7 @@
 - version: "0.8.1"
   date: 2021-02-23
   changes:
-  
+
   - type: bug
     impact: patch
     title: fix args qps and burst of tenant controller deployment
@@ -104,7 +120,7 @@
       and `--gen-mocks` to select what should be generated.
       If none of the `--gen-*` options is specified, _all_ generators are enabled.
     pullRequestNumber: 208
-  
+
   - type: enhancement
     impact: minor
     title: "Client-side rate limiting configurable for tenant controller"
@@ -134,8 +150,8 @@
       Jenkinsfile Runner container entrypoint retries cloning the pipeline
       repository. The retry parameters (retry interval and timeout) are now
       configurable via Helm chart parameters.
-      Jenkinsfile Runner image version which enables configuring retry 
-      parameters is also updated in the same PR. Changes in the new 
+      Jenkinsfile Runner image version which enables configuring retry
+      parameters is also updated in the same PR. Changes in the new
       release of JFR image can be found [here](https://github.com/SAP/stewardci-jenkinsfilerunner-image/releases/tag/210205_1988c5e).
     pullRequestNumber: 209
     jiraIssueNumber: 350
@@ -152,7 +168,7 @@
   - type: enhancement
     impact: minor
     title: "Add maintenance mode to run controller"
-    description: |- 
+    description: |-
       Steward can be put in _maintenance mode_.
       It prevents _new_ pipeline runs to be processed, while pipeline runs that are in progress _already_ still run to completion.
     pullRequestNumber: 204
@@ -165,7 +181,7 @@
       The state history of a pipeline run is not updated correctly if a concurrent change happens.
       This change will fix this bug.
     pullRequestNumber: 206
-  
+
   - type: security
     impact: patch
     title: "network: don't allow local subnet multicast traffic"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/lithammer/dedent v1.1.0
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -716,6 +716,8 @@ github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/pkg/apis/steward/v1alpha1/constants.go
+++ b/pkg/apis/steward/v1alpha1/constants.go
@@ -4,6 +4,7 @@ import (
 	"github.com/SAP/stewardci-core/pkg/apis/steward"
 )
 
+// annotations
 const (
 	// AnnotationTenantNamespacePrefix is the key of the annotation
 	// of a Steward client namespace defining the prefix of tenant namespaces
@@ -24,13 +25,47 @@ const (
 	// If this annotation is set on a secret it will be created in the run namespace
 	// with this name if it is listed in the pipelineRuns spec.secrets list.
 	AnnotationSecretRename = steward.GroupName + "/secret-rename-to"
+)
 
+// labels
+const (
 	// LabelSystemManaged is the key of the label whose presence indicates
 	// that this resource is managed by the Steward system and should not be
 	// modified otherwise.
 	// The value of the label is ignored and should be empty.
 	LabelSystemManaged = steward.GroupName + "/system-managed"
 
+	// LabelOwnerClientName is the key of the label that identifies the Steward
+	// _client_ that the labelled object is owned by.
+	// As Steward clients are currently represented by K8s namespaces only,
+	// the label value is the name of the respective client namespace.
+	// This may change in the future when Steward clients are represented by
+	// dedicated custom resources.
+	LabelOwnerClientName = steward.GroupName + "/owner-client-name"
+
+	// LabelOwnerClientNamespace is the key of the label that identifies the
+	// namespace assigned to the Steward _client_ that the labelled object is
+	// owned by.
+	LabelOwnerClientNamespace = steward.GroupName + "/owner-client-namespace"
+
+	// LabelOwnerTenantName is the key of the label that identifies the Steward
+	// _tenant_ that the labelled object is owned by.
+	// The label value is the name of the Tenant custom resource.
+	LabelOwnerTenantName = steward.GroupName + "/owner-tenant-name"
+
+	// LabelOwnerTenantNamespace is the key of the label that identifies the
+	// namespace assigned to the Steward _tenant_ that the labelled object is
+	// owned by.
+	LabelOwnerTenantNamespace = steward.GroupName + "/owner-tenant-namespace"
+
+	// LabelOwnerPipelineRunName is the key of the label that identifies the
+	// Steward _pipeline run_ that the labelled object is owned by.
+	// The label value is the name of the PipelineRun custom resource.
+	LabelOwnerPipelineRunName = steward.GroupName + "/owner-pipelinerun-name"
+)
+
+// K8s events
+const (
 	// EventReasonPreparingFailed is the reason for a event occuring when the run controller
 	// faces an intermittent error during preparing phase.
 	EventReasonPreparingFailed = "PreparingFailed"

--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -154,15 +154,16 @@ type PipelineStatus struct {
 	// +optional
 	FinishedAt *metav1.Time `json:"finishedAt,omitempty"`
 
-	State        State                 `json:"state"`
-	StateDetails StateItem             `json:"stateDetails"`
-	StateHistory []StateItem           `json:"stateHistory"`
-	Result       Result                `json:"result"`
-	Container    corev1.ContainerState `json:"container,omitempty"`
-	MessageShort string                `json:"messageShort"`
-	Message      string                `json:"message"`
-	History      []string              `json:"history"`
-	Namespace    string                `json:"namespace"`
+	State              State                 `json:"state"`
+	StateDetails       StateItem             `json:"stateDetails"`
+	StateHistory       []StateItem           `json:"stateHistory"`
+	Result             Result                `json:"result"`
+	Container          corev1.ContainerState `json:"container,omitempty"`
+	MessageShort       string                `json:"messageShort"`
+	Message            string                `json:"message"`
+	History            []string              `json:"history"`
+	Namespace          string                `json:"namespace"`
+	AuxiliaryNamespace string                `json:"auxiliaryNamespace"`
 }
 
 // StateItem holds start and end time of a state in the history

--- a/pkg/featureflag/flags.go
+++ b/pkg/featureflag/flags.go
@@ -4,6 +4,10 @@ var (
 	// Dummy shows how to define a feature flag. DO NOT USE IT!
 	Dummy = New("Dummy", Bool(false))
 
+	// CreateAuxNamespaceIfUnused controls whether auxiliary namespaces for
+	// pipeline runs are created although they are not used.
+	CreateAuxNamespaceIfUnused = New("CreateAuxNamespaceIfUnused", Bool(false))
+
 	// RetryOnInvalidPipelineRunsConfig controls whether the execution of a pipeline run
 	// is failed or retried on pipeline run configuration errors.
 	RetryOnInvalidPipelineRunsConfig = New("RetryOnInvalidPipelineRunsConfig", Bool(false))

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -280,6 +280,34 @@ func (mr *MockPipelineRunMockRecorder) DeleteFinalizerIfExists() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFinalizerIfExists", reflect.TypeOf((*MockPipelineRun)(nil).DeleteFinalizerIfExists))
 }
 
+// GetAPIObject mocks base method
+func (m *MockPipelineRun) GetAPIObject() *v1alpha1.PipelineRun {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIObject")
+	ret0, _ := ret[0].(*v1alpha1.PipelineRun)
+	return ret0
+}
+
+// GetAPIObject indicates an expected call of GetAPIObject
+func (mr *MockPipelineRunMockRecorder) GetAPIObject() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIObject", reflect.TypeOf((*MockPipelineRun)(nil).GetAPIObject))
+}
+
+// GetAuxNamespace mocks base method
+func (m *MockPipelineRun) GetAuxNamespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuxNamespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAuxNamespace indicates an expected call of GetAuxNamespace
+func (mr *MockPipelineRunMockRecorder) GetAuxNamespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuxNamespace", reflect.TypeOf((*MockPipelineRun)(nil).GetAuxNamespace))
+}
+
 // GetKey mocks base method
 func (m *MockPipelineRun) GetKey() string {
 	m.ctrl.T.Helper()
@@ -433,6 +461,20 @@ func (m *MockPipelineRun) String() string {
 func (mr *MockPipelineRunMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockPipelineRun)(nil).String))
+}
+
+// UpdateAuxNamespace mocks base method
+func (m *MockPipelineRun) UpdateAuxNamespace(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAuxNamespace", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAuxNamespace indicates an expected call of UpdateAuxNamespace
+func (mr *MockPipelineRunMockRecorder) UpdateAuxNamespace(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAuxNamespace", reflect.TypeOf((*MockPipelineRun)(nil).UpdateAuxNamespace), arg0)
 }
 
 // UpdateContainer mocks base method

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -51,7 +51,7 @@ type Controller struct {
 
 type controllerTesting struct {
 	runManagerStub             run.Manager
-	newRunManagerStub          func(k8s.ClientFactory, secrets.SecretProvider, k8s.NamespaceManager) run.Manager
+	newRunManagerStub          func(k8s.ClientFactory, secrets.SecretProvider) run.Manager
 	loadPipelineRunsConfigStub func() (*cfg.PipelineRunsConfigStruct, error)
 	isMaintenanceModeStub      func() (bool, error)
 }
@@ -205,16 +205,15 @@ func (c *Controller) createRunManager(pipelineRun k8s.PipelineRun) run.Manager {
 	}
 	tenant := k8s.NewTenantNamespace(c.factory, pipelineRun.GetNamespace())
 	workFactory := tenant.TargetClientFactory()
-	namespaceManager := k8s.NewNamespaceManager(c.factory, runNamespacePrefix, runNamespaceRandomLength)
-	return c.newRunManager(workFactory, tenant.GetSecretProvider(), namespaceManager)
+	return c.newRunManager(workFactory, tenant.GetSecretProvider())
 }
 
-func (c *Controller) newRunManager(workFactory k8s.ClientFactory, secretProvider secrets.SecretProvider, namespaceManager k8s.NamespaceManager) run.Manager {
+func (c *Controller) newRunManager(workFactory k8s.ClientFactory, secretProvider secrets.SecretProvider) run.Manager {
 	if c.testing != nil && c.testing.newRunManagerStub != nil {
-		return c.testing.newRunManagerStub(workFactory, secretProvider, namespaceManager)
+		return c.testing.newRunManagerStub(workFactory, secretProvider)
 
 	}
-	return NewRunManager(workFactory, secretProvider, namespaceManager)
+	return newRunManager(workFactory, secretProvider)
 }
 
 func (c *Controller) loadPipelineRunsConfig() (*cfg.PipelineRunsConfigStruct, error) {

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	klog "k8s.io/klog/v2"
@@ -29,8 +30,9 @@ import (
 
 func Test_Controller_Success(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
-	cf := fake.NewClientFactory(
+	cf := newFakeClientFactory(
 		fake.SecretOpaque("secret1", "ns1"),
 		fake.ClusterRole(string(runClusterRoleName)),
 	)
@@ -41,10 +43,10 @@ func Test_Controller_Success(t *testing.T) {
 	// EXERCISE
 	stopCh := startController(t, cf)
 	defer stopController(t, stopCh)
-	createRun(pr, cf)
+	createRun(t, pr, cf)
+
 	// VERIFY
-	run, err := getPipelineRun("run1", "ns1", cf)
-	assert.NilError(t, err)
+	run := getPipelineRun(t, "run1", "ns1", cf)
 	status := run.GetStatus()
 
 	assert.Assert(t, !strings.Contains(status.Message, "ERROR"), status.Message)
@@ -54,8 +56,9 @@ func Test_Controller_Success(t *testing.T) {
 
 func Test_Controller_Running(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
-	cf := fake.NewClientFactory(
+	cf := newFakeClientFactory(
 		fake.SecretOpaque("secret1", "ns1"),
 		fake.ClusterRole(string(runClusterRoleName)),
 	)
@@ -66,29 +69,29 @@ func Test_Controller_Running(t *testing.T) {
 	// EXERCISE
 	stopCh := startController(t, cf)
 	defer stopController(t, stopCh)
-	createRun(pr, cf)
+	createRun(t, pr, cf)
+
 	// VERIFY
-	run, err := getPipelineRun("run1", "ns1", cf)
-	assert.NilError(t, err)
+	run := getPipelineRun(t, "run1", "ns1", cf)
 	runNs := run.GetRunNamespace()
-	taskRun, _ := getTektonTaskRun(runNs, cf)
+	taskRun := getTektonTaskRun(t, runNs, cf)
 	now := metav1.Now()
 	taskRun.Status.StartTime = &now
-	updateTektonTaskRun(taskRun, runNs, cf)
+	updateTektonTaskRun(t, taskRun, runNs, cf)
 	cf.Sleep("Waiting for Tekton TaskRun being started")
-	run, err = getPipelineRun("run1", "ns1", cf)
-	assert.NilError(t, err)
+	run = getPipelineRun(t, "run1", "ns1", cf)
 	status := run.GetStatus()
 	assert.Equal(t, api.StateRunning, status.State)
 }
 
 func Test_Controller_Deletion(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
 	pr := fake.PipelineRun("run1", "ns1", api.PipelineSpec{
 		Secrets: []string{"secret1"},
 	})
-	cf := fake.NewClientFactory(
+	cf := newFakeClientFactory(
 		fake.SecretOpaque("secret1", "ns1"),
 		fake.ClusterRole(string(runClusterRoleName)),
 	)
@@ -96,29 +99,30 @@ func Test_Controller_Deletion(t *testing.T) {
 	// EXERCISE
 	stopCh := startController(t, cf)
 	defer stopController(t, stopCh)
-	createRun(pr, cf)
+	createRun(t, pr, cf)
+
 	// VERIFY
-	run, _ := getRun("run1", "ns1", cf)
+	run := getRun(t, "run1", "ns1", cf)
 
 	assert.Equal(t, 1, len(run.GetFinalizers()))
 
 	now := metav1.Now()
 	run.SetDeletionTimestamp(&now)
-	updateRun(run, "ns1", cf)
+	updateRun(t, run, "ns1", cf)
 
 	cf.Sleep("Wait for deletion")
-	run, _ = getRun("run1", "ns1", cf)
+	run = getRun(t, "run1", "ns1", cf)
 	assert.Equal(t, 0, len(run.GetFinalizers()))
-
 }
 
 func Test_Controller_syncHandler_givesUp_onPipelineRunNotFound(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	cf := fake.NewClientFactory()
+	cf := newFakeClientFactory()
 	mockPipelineRunFetcher := mocks.NewMockPipelineRunFetcher(mockCtrl)
 	mockPipelineRunFetcher.EXPECT().
 		ByKey(gomock.Any()).
@@ -128,14 +132,13 @@ func Test_Controller_syncHandler_givesUp_onPipelineRunNotFound(t *testing.T) {
 
 	// EXERCISE
 	err := examinee.syncHandler("foo/bar")
+
 	// VERIFY
 	assert.NilError(t, err)
 }
 
 func newController(runs ...*api.PipelineRun) (*Controller, *fake.ClientFactory) {
-	cf := fake.NewClientFactory(fake.ClusterRole(string(runClusterRoleName)))
-	cs := cf.StewardClientset()
-	cs.PrependReactor("create", "*", fake.NewCreationTimestampReactor())
+	cf := newFakeClientFactory(fake.ClusterRole(string(runClusterRoleName)))
 	client := cf.StewardV1alpha1()
 	for _, run := range runs {
 		client.PipelineRuns(run.GetNamespace()).Create(run)
@@ -187,6 +190,7 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test := test
 			t.Parallel()
+
 			// SETUP
 			run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
 			if test.hasFinalizer {
@@ -203,8 +207,10 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 				runManagerStub:             runManager,
 				loadPipelineRunsConfigStub: newEmptyRunsConfig,
 			}
+
 			// EXERCISE
 			err := controller.syncHandler("ns1/foo")
+
 			// VERIFY
 			if test.expectedError {
 				assert.Assert(t, err != nil)
@@ -227,13 +233,13 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 func Test_Controller_syncHandler_mock_start(t *testing.T) {
 	error1 := fmt.Errorf("error1")
 	errorRecover1 := serrors.Recoverable(error1)
+
 	for _, currentStatus := range []api.PipelineStatus{
-		api.PipelineStatus{},
-		api.PipelineStatus{
+		{},
+		{
 			State: api.StateNew,
 		},
 	} {
-
 		for _, test := range []struct {
 			name                   string
 			pipelineSpec           api.PipelineSpec
@@ -245,7 +251,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 			expectedMessage        string
 			expectedError          error
 		}{
-			{name: "new_ok",
+			{
+				name:         "new_ok",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
@@ -255,7 +262,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedResult:         api.ResultUndefined,
 				expectedState:          api.StateWaiting,
 			},
-			{name: "new_maintenance_error_a",
+			{
+				name:                   "new_maintenance_error_a",
 				pipelineSpec:           api.PipelineSpec{},
 				runManagerExpectation:  func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
@@ -264,7 +272,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedState:          api.StateNew,
 				expectedError:          error1,
 			},
-			{name: "new_maintenance_error_b",
+			{
+				name:                   "new_maintenance_error_b",
 				pipelineSpec:           api.PipelineSpec{},
 				runManagerExpectation:  func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
@@ -273,7 +282,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedState:          api.StateNew,
 				expectedError:          error1,
 			},
-			{name: "new_maintenance",
+			{
+				name:         "new_maintenance",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 				},
@@ -283,7 +293,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedState:          api.StateNew,
 				expectedError:          fmt.Errorf("pipeline execution is paused while the system is in maintenance mode"),
 			},
-			{name: "new_get_cofig_fail_not_recoverable",
+			{
+				name:         "new_get_cofig_fail_not_recoverable",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 				},
@@ -294,7 +305,8 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedResult:        api.ResultErrorInfra,
 				expectedState:         api.StateFinished,
 			},
-			{name: "new_get_cofig_fail_recoverable",
+			{
+				name:         "new_get_cofig_fail_recoverable",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 				},
@@ -310,6 +322,7 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test := test
 				t.Parallel()
+
 				// SETUP
 				run := fake.PipelineRun("foo", "ns1", test.pipelineSpec)
 				run.Status = currentStatus
@@ -324,17 +337,20 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 					loadPipelineRunsConfigStub: test.pipelineRunsConfigStub,
 					isMaintenanceModeStub:      test.isMaintenanceModeStub,
 				}
+
 				// EXERCISE
 				resultErr := controller.syncHandler("ns1/foo")
+
 				// VERIFY
 				if test.expectedError != nil {
 					assert.Error(t, resultErr, test.expectedError.Error())
 				} else {
 					assert.NilError(t, resultErr)
 				}
+
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
-				klog.Infof("%+v", result.Status)
+				t.Logf("%+v", result.Status)
 				assert.Equal(t, test.expectedResult, result.Status.Result, test.name)
 				assert.Equal(t, test.expectedState, result.Status.State, test.name)
 
@@ -355,6 +371,7 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 func Test_Controller_syncHandler_mock(t *testing.T) {
 	error1 := fmt.Errorf("error1")
 	errorRecover1 := serrors.Recoverable(error1)
+
 	for _, maintenanceMode := range []bool{true, false} {
 
 		for _, test := range []struct {
@@ -368,7 +385,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 			expectedMessage        string
 			expectedError          error
 		}{
-			{name: "preparing_ok",
+			{
+				name:         "preparing_ok",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StatePreparing,
@@ -380,7 +398,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         api.ResultUndefined,
 				expectedState:          api.StateWaiting,
 			},
-			{name: "preparing_fail",
+			{
+				name:         "preparing_fail",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StatePreparing,
@@ -394,7 +413,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedMessage:        "",
 				expectedError:          error1,
 			},
-			{name: "preparing_fail_on_content_error_during_start",
+			{
+				name: "preparing_fail_on_content_error_during_start",
 				pipelineSpec: api.PipelineSpec{
 					Secrets: []string{"secret1"},
 				},
@@ -410,7 +430,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedState:          api.StateCleaning,
 				expectedMessage:        "preparing failed .*error1",
 			},
-			{name: "waiting_fail",
+			{
+				name:         "waiting_fail",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateWaiting,
@@ -422,7 +443,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         api.ResultErrorInfra,
 				expectedState:          api.StateCleaning,
 			},
-			{name: "waiting_recover",
+			{
+				name:         "waiting_recover",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateWaiting,
@@ -435,7 +457,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedState:          api.StateWaiting,
 				expectedError:          errorRecover1,
 			},
-			{name: "waiting_not_started",
+			{
+				name:         "waiting_not_started",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateWaiting,
@@ -448,7 +471,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         "",
 				expectedState:          api.StateWaiting,
 			},
-			{name: "waiting_started",
+			{
+				name:         "waiting_started",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateWaiting,
@@ -462,7 +486,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         "",
 				expectedState:          api.StateRunning,
 			},
-			{name: "running_not_finished",
+			{
+				name:         "running_not_finished",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateRunning,
@@ -476,7 +501,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         "",
 				expectedState:          api.StateRunning,
 			},
-			{name: "running_recover",
+			{
+				name:         "running_recover",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateRunning,
@@ -489,7 +515,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedState:          api.StateRunning,
 				expectedError:          errorRecover1,
 			},
-			{name: "running_get_error",
+			{
+				name:         "running_get_error",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateRunning,
@@ -502,7 +529,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedState:          api.StateCleaning,
 				expectedMessage:        "running failed .*error1",
 			},
-			{name: "running_finished_timeout",
+			{
+				name:         "running_finished_timeout",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateRunning,
@@ -520,7 +548,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         api.ResultTimeout,
 				expectedState:          api.StateCleaning,
 			},
-			{name: "running_finished_terminated",
+			{
+				name:         "running_finished_terminated",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateRunning,
@@ -540,7 +569,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         api.ResultSuccess,
 				expectedState:          api.StateCleaning,
 			},
-			{name: "skip_finished",
+			{
+				name:         "skip_finished",
 				pipelineSpec: api.PipelineSpec{},
 				currentStatus: api.PipelineStatus{
 					State: api.StateFinished,
@@ -551,7 +581,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         "",
 				expectedState:          api.StateFinished,
 			},
-			{name: "cleanup_abborted_new",
+			{
+				name: "cleanup_abborted_new",
 				pipelineSpec: api.PipelineSpec{
 					Intent: api.IntentAbort,
 				},
@@ -565,7 +596,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				expectedResult:         api.ResultAborted,
 				expectedState:          api.StateFinished,
 			},
-			{name: "cleanup_abborted_running",
+			{
+				name: "cleanup_abborted_running",
 				pipelineSpec: api.PipelineSpec{
 					Intent: api.IntentAbort,
 				},
@@ -583,6 +615,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 			t.Run(fmt.Sprintf("%+s_maintenanceMode_%t", test.name, maintenanceMode), func(t *testing.T) {
 				test := test
 				t.Parallel()
+
 				// SETUP
 				run := fake.PipelineRun("foo", "ns1", test.pipelineSpec)
 				run.Status = test.currentStatus
@@ -597,17 +630,20 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					loadPipelineRunsConfigStub: test.pipelineRunsConfigStub,
 					isMaintenanceModeStub:      newIsMaintenanceModeStub(maintenanceMode, nil),
 				}
+
 				// EXERCISE
 				err := controller.syncHandler("ns1/foo")
+
 				// VERIFY
 				if test.expectedError != nil {
 					assert.Equal(t, test.expectedError, err)
 				} else {
 					assert.NilError(t, err)
 				}
+
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
-				klog.Infof("%+v", result.Status)
+				t.Logf("%+v", result.Status)
 				assert.Equal(t, test.expectedResult, result.Status.Result, test.name)
 				assert.Equal(t, test.expectedState, result.Status.State, test.name)
 
@@ -627,11 +663,12 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 
 func Test_Controller_syncHandler_initiatesRetrying_on500DuringPipelineRunFetch(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	cf := fake.NewClientFactory()
+	cf := newFakeClientFactory()
 	mockPipelineRunFetcher := mocks.NewMockPipelineRunFetcher(mockCtrl)
 	message := "k8s kapot!"
 	mockPipelineRunFetcher.EXPECT().
@@ -640,16 +677,19 @@ func Test_Controller_syncHandler_initiatesRetrying_on500DuringPipelineRunFetch(t
 
 	examinee := NewController(cf, metrics.NewMetrics())
 	examinee.pipelineRunFetcher = mockPipelineRunFetcher
+
 	// EXERCISE
 	err := examinee.syncHandler("foo/bar")
+
 	// VERIFY
 	assert.ErrorContains(t, err, message)
 }
 
 func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 	t.Parallel()
+
 	// SETUP
-	cf := fake.NewClientFactory(
+	cf := newFakeClientFactory(
 
 		// the tenant namespace
 		fake.Namespace("tenant-ns-1"),
@@ -716,9 +756,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 	defer stopController(t, stopCh)
 
 	// VERIFY
-	run, err := getPipelineRun("run1", "tenant-ns-1", cf)
-	assert.NilError(t, err)
-
+	run := getPipelineRun(t, "run1", "tenant-ns-1", cf)
 	status := run.GetStatus()
 
 	assert.Assert(t, status != nil)
@@ -728,8 +766,8 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 	assert.Equal(t, "message from Succeeded condition", status.Message)
 }
 
-func newTestRunManager(workFactory k8s.ClientFactory, secretProvider secrets.SecretProvider, namespaceManager k8s.NamespaceManager) run.Manager {
-	runManager := NewRunManager(workFactory, secretProvider, namespaceManager).(*runManager)
+func newTestRunManager(workFactory k8s.ClientFactory, secretProvider secrets.SecretProvider) run.Manager {
+	runManager := newRunManager(workFactory, secretProvider)
 	runManager.testing = &runManagerTesting{
 		getServiceAccountSecretNameStub: func(ctx *runContext) string { return "foo" },
 	}
@@ -737,8 +775,6 @@ func newTestRunManager(workFactory k8s.ClientFactory, secretProvider secrets.Sec
 }
 
 func startController(t *testing.T, cf *fake.ClientFactory) chan struct{} {
-	cs := cf.StewardClientset()
-	cs.PrependReactor("create", "*", fake.NewCreationTimestampReactor())
 	stopCh := make(chan struct{}, 0)
 	metrics := metrics.NewMetrics()
 	controller := NewController(cf, metrics)
@@ -762,6 +798,7 @@ func stopController(t *testing.T, stopCh chan struct{}) {
 }
 
 func start(t *testing.T, controller *Controller, stopCh chan struct{}) {
+	t.Helper()
 	if err := controller.Run(1, stopCh); err != nil {
 		t.Logf("Error running controller %s", err.Error())
 	}
@@ -771,40 +808,74 @@ func resource(resource string) schema.GroupResource {
 	return schema.GroupResource{Group: "", Resource: resource}
 }
 
-// GetPipelineRun returns the pipeline run with the given name in the given namespace.
-// Return nil if not found.
-func getPipelineRun(name string, namespace string, cf *fake.ClientFactory) (k8s.PipelineRun, error) {
+func getPipelineRun(t *testing.T, name string, namespace string, cf *fake.ClientFactory) k8s.PipelineRun {
+	t.Helper()
 	key := fake.ObjectKey(name, namespace)
 	fetcher := k8s.NewClientBasedPipelineRunFetcher(cf.StewardV1alpha1())
 	pipelineRun, err := fetcher.ByKey(key)
 	if err != nil {
-		return nil, err
+		t.Fatalf("could not get pipeline run: %s", err.Error())
 	}
-	return k8s.NewPipelineRun(pipelineRun, cf)
+	wrapper, err := k8s.NewPipelineRun(pipelineRun, cf)
+	if err != nil {
+		t.Fatalf("could not get pipeline run: %s", err.Error())
+	}
+	return wrapper
 }
 
-func createRun(run *api.PipelineRun, cf *fake.ClientFactory) error {
+func createRun(t *testing.T, run *api.PipelineRun, cf *fake.ClientFactory) {
+	t.Helper()
 	_, err := cf.StewardV1alpha1().PipelineRuns(run.GetNamespace()).Create(run)
-	if err == nil {
-		cf.Sleep("wait for controller to pick up run")
+	if err != nil {
+		t.Fatalf("failed to create pipeline run: %s", err.Error())
 	}
-	return err
+	cf.Sleep("wait for controller to pick up run")
 }
 
-func getRun(name, namespace string, cf *fake.ClientFactory) (*api.PipelineRun, error) {
-	return cf.StewardV1alpha1().PipelineRuns(namespace).Get(name, metav1.GetOptions{})
+func getRun(t *testing.T, name, namespace string, cf *fake.ClientFactory) *api.PipelineRun {
+	t.Helper()
+	run, err := cf.StewardV1alpha1().PipelineRuns(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get run: %s", err.Error())
+	}
+	return run
 }
 
-func updateRun(run *api.PipelineRun, namespace string, cf *fake.ClientFactory) (*api.PipelineRun, error) {
-	return cf.StewardV1alpha1().PipelineRuns(namespace).Update(run)
+func updateRun(t *testing.T, run *api.PipelineRun, namespace string, cf *fake.ClientFactory) *api.PipelineRun {
+	t.Helper()
+	updated, err := cf.StewardV1alpha1().PipelineRuns(namespace).Update(run)
+	if err != nil {
+		t.Fatalf("could not update run: %s", err.Error())
+	}
+	return updated
 }
 
-func getTektonTaskRun(namespace string, cf *fake.ClientFactory) (*tekton.TaskRun, error) {
-	return cf.TektonV1beta1().TaskRuns(namespace).Get(tektonTaskRunName, metav1.GetOptions{})
+func getTektonTaskRun(t *testing.T, namespace string, cf *fake.ClientFactory) *tekton.TaskRun {
+	t.Helper()
+	taskRun, err := cf.TektonV1beta1().TaskRuns(namespace).Get(tektonTaskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get Tekton task run: %s", err.Error())
+	}
+	return taskRun
 }
 
-func updateTektonTaskRun(taskRun *tekton.TaskRun, namespace string, cf *fake.ClientFactory) (*tekton.TaskRun, error) {
-	return cf.TektonV1beta1().TaskRuns(namespace).Update(taskRun)
+func updateTektonTaskRun(t *testing.T, taskRun *tekton.TaskRun, namespace string, cf *fake.ClientFactory) *tekton.TaskRun {
+	t.Helper()
+	updated, err := cf.TektonV1beta1().TaskRuns(namespace).Update(taskRun)
+	if err != nil {
+		t.Fatalf("could not update Tekton task run: %s", err.Error())
+	}
+	return updated
+}
+
+func newFakeClientFactory(objects ...runtime.Object) *fake.ClientFactory {
+	cf := fake.NewClientFactory(objects...)
+
+	cf.KubernetesClientset().PrependReactor("create", "*", fake.GenerateNameReactor(0))
+
+	cf.StewardClientset().PrependReactor("create", "*", fake.NewCreationTimestampReactor())
+
+	return cf
 }
 
 func newIsMaintenanceModeStub(maintenanceMode bool, err error) func() (bool, error) {

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SAP/stewardci-core/pkg/runctl/cfg"
 	runifc "github.com/SAP/stewardci-core/pkg/runctl/run"
 	"github.com/SAP/stewardci-core/pkg/runctl/secretmgr"
+	slabels "github.com/SAP/stewardci-core/pkg/stewardlabels"
 	"github.com/pkg/errors"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1api "k8s.io/api/core/v1"
@@ -264,9 +265,6 @@ func (c *runManager) setupNetworkPolicyThatIsolatesAllPods(ctx *runContext) erro
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: steward.GroupName + "--isolate-all-",
 			Namespace:    ctx.runNamespace,
-			Labels: map[string]string{
-				v1alpha1.LabelSystemManaged: "",
-			},
 		},
 		Spec: networkingv1api.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{}, // select all pods from namespace
@@ -276,6 +274,8 @@ func (c *runManager) setupNetworkPolicyThatIsolatesAllPods(ctx *runContext) erro
 			},
 		},
 	}
+
+	slabels.LabelAsSystemManaged(policy)
 
 	policyIfce := c.factory.NetworkingV1().NetworkPolicies(ctx.runNamespace)
 	if _, err := policyIfce.Create(policy); err != nil {
@@ -409,9 +409,8 @@ func (c *runManager) createResource(configStr string, resource string, resourceD
 
 		obj.SetGenerateName(steward.GroupName + "--configured-")
 		obj.SetNamespace(ctx.runNamespace)
-		obj.SetLabels(map[string]string{
-			v1alpha1.LabelSystemManaged: "",
-		})
+
+		slabels.LabelAsSystemManaged(obj)
 	}
 
 	// create resource object

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -7,14 +7,16 @@ import (
 	"strings"
 
 	steward "github.com/SAP/stewardci-core/pkg/apis/steward"
-	"github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	serrors "github.com/SAP/stewardci-core/pkg/errors"
+	"github.com/SAP/stewardci-core/pkg/featureflag"
 	"github.com/SAP/stewardci-core/pkg/k8s"
 	secrets "github.com/SAP/stewardci-core/pkg/k8s/secrets"
 	"github.com/SAP/stewardci-core/pkg/runctl/cfg"
 	runifc "github.com/SAP/stewardci-core/pkg/runctl/run"
 	"github.com/SAP/stewardci-core/pkg/runctl/secretmgr"
 	slabels "github.com/SAP/stewardci-core/pkg/stewardlabels"
+	"github.com/SAP/stewardci-core/pkg/utils"
 	"github.com/pkg/errors"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1api "k8s.io/api/core/v1"
@@ -25,12 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlserial "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/util/retry"
 	klog "k8s.io/klog/v2"
 )
 
 const (
 	runNamespacePrefix       = "steward-run"
-	runNamespaceRandomLength = 16
+	runNamespaceRandomLength = 5
 	serviceAccountName       = "default"
 
 	// in general, the token of the above service account should not be automatically mounted into pods
@@ -52,9 +55,8 @@ const (
 )
 
 type runManager struct {
-	factory          k8s.ClientFactory
-	namespaceManager k8s.NamespaceManager
-	secretProvider   secrets.SecretProvider
+	factory        k8s.ClientFactory
+	secretProvider secrets.SecretProvider
 
 	testing *runManagerTesting
 }
@@ -78,15 +80,15 @@ type runContext struct {
 	pipelineRun        k8s.PipelineRun
 	pipelineRunsConfig *cfg.PipelineRunsConfigStruct
 	runNamespace       string
+	auxNamespace       string
 	serviceAccount     *k8s.ServiceAccountWrap
 }
 
-// NewRunManager creates a new RunManager.
-func NewRunManager(factory k8s.ClientFactory, secretProvider secrets.SecretProvider, namespaceManager k8s.NamespaceManager) runifc.Manager {
+// newRunManager creates a new runManager.
+func newRunManager(factory k8s.ClientFactory, secretProvider secrets.SecretProvider) *runManager {
 	return &runManager{
-		factory:          factory,
-		namespaceManager: namespaceManager,
-		secretProvider:   secretProvider,
+		factory:        factory,
+		secretProvider: secretProvider,
 	}
 }
 
@@ -97,8 +99,10 @@ func (c *runManager) Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.
 	ctx := &runContext{
 		pipelineRun:        pipelineRun,
 		pipelineRunsConfig: pipelineRunsConfig,
+		runNamespace:       pipelineRun.GetRunNamespace(),
+		auxNamespace:       pipelineRun.GetAuxNamespace(),
 	}
-	err = c.cleanupPreviousAttempt(ctx)
+	err = c.cleanup(ctx)
 	if err != nil {
 		return err
 	}
@@ -114,26 +118,29 @@ func (c *runManager) Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.
 	return nil
 }
 
-func (c *runManager) cleanupPreviousAttempt(ctx *runContext) error {
-	runNamespace := ctx.pipelineRun.GetRunNamespace()
-	if runNamespace != "" {
-		ctx.runNamespace = runNamespace
-		return c.cleanup(ctx)
-	}
-	return nil
-}
-
 // prepareRunNamespace creates a new namespace for the pipeline run
 // and populates it with needed resources.
 func (c *runManager) prepareRunNamespace(ctx *runContext) error {
 	var err error
 
-	ctx.runNamespace, err = c.namespaceManager.Create("", nil)
+	randName, err := utils.RandomAlphaNumString(runNamespaceRandomLength)
 	if err != nil {
-		return errors.Wrap(err, "failed to create run namespace")
+		return err
 	}
 
+	ctx.runNamespace, err = c.createNamespace(ctx, "main", randName)
+	if err != nil {
+		return errors.Wrap(err, "failed to create main run namespace")
+	}
 	ctx.pipelineRun.UpdateRunNamespace(ctx.runNamespace)
+
+	if featureflag.CreateAuxNamespaceIfUnused.Enabled() {
+		ctx.auxNamespace, err = c.createNamespace(ctx, "aux", randName)
+		if err != nil {
+			return errors.Wrap(err, "failed to create auxiliary run namespace")
+		}
+		ctx.pipelineRun.UpdateAuxNamespace(ctx.auxNamespace)
+	}
 
 	// If something goes wrong while creating objects inside the namespaces, we delete everything.
 	cleanupOnError := func() {
@@ -297,7 +304,7 @@ func (c *runManager) setupNetworkPolicyFromConfig(ctx *runContext) error {
 		networkProfile = spec.Profiles.Network
 
 		if _, exists := ctx.pipelineRunsConfig.NetworkPolicies[networkProfile]; !exists {
-			return serrors.Classify(fmt.Errorf("network profile %q does not exist", networkProfile), v1alpha1.ResultErrorConfig)
+			return serrors.Classify(fmt.Errorf("network profile %q does not exist", networkProfile), stewardv1alpha1.ResultErrorConfig)
 		}
 	}
 
@@ -502,7 +509,7 @@ func (c *runManager) createTektonTaskRun(ctx *runContext) error {
 	c.addTektonTaskRunParamsForPipeline(ctx, &tektonTaskRun)
 	err = c.addTektonTaskRunParamsForLoggingElasticsearch(ctx, &tektonTaskRun)
 	if err != nil {
-		return serrors.Classify(err, v1alpha1.ResultErrorConfig)
+		return serrors.Classify(err, stewardv1alpha1.ResultErrorConfig)
 	}
 
 	c.addTektonTaskRunParamsForRunDetails(ctx, &tektonTaskRun)
@@ -641,7 +648,6 @@ func (c *runManager) GetRun(pipelineRun k8s.PipelineRun) (runifc.Run, error) {
 				k8serrors.IsUnexpectedServerError(err))
 	}
 	return NewRun(run), nil
-
 }
 
 // Cleanup a run based on a pipelineRun
@@ -649,6 +655,7 @@ func (c *runManager) Cleanup(pipelineRun k8s.PipelineRun) error {
 	ctx := &runContext{
 		pipelineRun:  pipelineRun,
 		runNamespace: pipelineRun.GetRunNamespace(),
+		auxNamespace: pipelineRun.GetAuxNamespace(),
 	}
 	return c.cleanup(ctx)
 }
@@ -658,18 +665,105 @@ func (c *runManager) cleanup(ctx *runContext) error {
 		return c.testing.cleanupStub(ctx)
 	}
 
-	namespace := ctx.runNamespace
-	if namespace == "" {
-		//TODO: Don't store on resource as message. Add it as event.
-		ctx.pipelineRun.StoreErrorAsMessage(fmt.Errorf("Nothing to clean up as namespace not set"), "")
-	} else {
-		err := c.namespaceManager.Delete(namespace)
-		if err != nil {
-			ctx.pipelineRun.StoreErrorAsMessage(err, "error deleting namespace")
-			return err
+	var deleteOptions *metav1.DeleteOptions
+	{
+		deletePropagation := metav1.DeletePropagationBackground
+		deleteOptions = &metav1.DeleteOptions{
+			PropagationPolicy: &deletePropagation,
 		}
 	}
-	return nil
+
+	var firstErr error
+
+	namespacesToDelete := []string{
+		ctx.runNamespace,
+		ctx.auxNamespace,
+	}
+	for _, name := range namespacesToDelete {
+		if name == "" {
+			continue
+		}
+		err := c.deleteNamespace(name, deleteOptions)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if firstErr != nil {
+		// TODO Don't store on resource as message. Add it as event.
+		ctx.pipelineRun.StoreErrorAsMessage(firstErr, "cleanup failed")
+	}
+
+	return firstErr
+}
+
+func (c *runManager) createNamespace(ctx *runContext, purpose, randName string) (string, error) {
+	var err error
+
+	wanted := &corev1api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-%s-%s-", runNamespacePrefix, randName, purpose),
+		},
+	}
+
+	slabels.LabelAsSystemManaged(wanted)
+	err = slabels.LabelAsOwnedByPipelineRun(wanted, ctx.pipelineRun.GetAPIObject())
+	if err != nil {
+		return "", errors.Wrap(err, "failed to label namespace as owned by pipeline run")
+	}
+
+	isRetriable := func(err error) bool {
+		return k8serrors.IsConflict(err) ||
+			k8serrors.IsInternalError(err) ||
+			k8serrors.IsServerTimeout(err) ||
+			k8serrors.IsServiceUnavailable(err) ||
+			k8serrors.IsTimeout(err) ||
+			k8serrors.IsTooManyRequests(err) ||
+			k8serrors.IsUnexpectedServerError(err)
+	}
+
+	var created *corev1api.Namespace
+
+	err = retry.OnError(retry.DefaultBackoff, isRetriable,
+		func() error {
+			var err error
+			created, err = c.factory.CoreV1().Namespaces().Create(wanted)
+			return err
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return created.GetName(), err
+}
+
+func (c *runManager) deleteNamespace(name string, options *metav1.DeleteOptions) error {
+	isIgnorable := func(err error) bool {
+		return k8serrors.IsNotFound(err) ||
+			k8serrors.IsGone(err) ||
+			k8serrors.IsResourceExpired(err)
+	}
+
+	isRetriable := func(err error) bool {
+		return k8serrors.IsConflict(err) ||
+			k8serrors.IsInternalError(err) ||
+			k8serrors.IsServerTimeout(err) ||
+			k8serrors.IsServiceUnavailable(err) ||
+			k8serrors.IsTimeout(err) ||
+			k8serrors.IsTooManyRequests(err) ||
+			k8serrors.IsUnexpectedServerError(err)
+	}
+
+	return retry.OnError(retry.DefaultBackoff, isRetriable,
+		func() error {
+			err := c.factory.CoreV1().Namespaces().Delete(name, options)
+			if isIgnorable(err) {
+				return nil
+			}
+			return err
+		},
+	)
 }
 
 func toJSONString(value interface{}) (string, error) {

--- a/pkg/stewardlabels/labelling.go
+++ b/pkg/stewardlabels/labelling.go
@@ -1,0 +1,68 @@
+package stewardlabels
+
+import (
+	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LabelAsSystemManaged sets label `steward.sap.com/system-managed` at
+// the given object.
+func LabelAsSystemManaged(obj metav1.Object) {
+	if obj == nil {
+		return
+	}
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[stewardv1alpha1.LabelSystemManaged] = ""
+	obj.SetLabels(labels)
+}
+
+// LabelAsOwnedByClientNamespace sets some labels on `obj` that identify it
+// as owned by the Steward client represented by the given namespace.
+// Fails if there's a conflict with existing labels, e.g. `obj` is labelled
+// as owned by another Steward client.
+func LabelAsOwnedByClientNamespace(obj metav1.Object, owner *corev1.Namespace) error {
+	if obj == nil {
+		return nil
+	}
+	return propagate(obj, owner, map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      owner.GetName(),
+		stewardv1alpha1.LabelOwnerClientNamespace: owner.GetName(),
+	})
+}
+
+// LabelAsOwnedByTenant sets some labels on `obj` that identify it
+// as owned by the given Steward tenant.
+// Fails if there's a conflict with existing labels, e.g. `obj` is labelled
+// as owned by another Steward client or tenant.
+func LabelAsOwnedByTenant(obj metav1.Object, owner *stewardv1alpha1.Tenant) error {
+	if obj == nil {
+		return nil
+	}
+	return propagate(obj, owner, map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      owner.GetNamespace(),
+		stewardv1alpha1.LabelOwnerClientNamespace: owner.GetNamespace(),
+		stewardv1alpha1.LabelOwnerTenantName:      owner.GetName(),
+		stewardv1alpha1.LabelOwnerTenantNamespace: owner.Status.TenantNamespaceName,
+	})
+}
+
+// LabelAsOwnedByPipelineRun sets some labels on `obj` that identify it
+// as owned by the given Steward pipeline run.
+// Fails if there's a conflict with existing labels, e.g. `obj` is labelled
+// as owned by another Steward client, tenant or pipeline run.
+func LabelAsOwnedByPipelineRun(obj metav1.Object, owner *stewardv1alpha1.PipelineRun) error {
+	if obj == nil {
+		return nil
+	}
+	return propagate(obj, owner, map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      "",
+		stewardv1alpha1.LabelOwnerClientNamespace: "",
+		stewardv1alpha1.LabelOwnerTenantName:      "",
+		stewardv1alpha1.LabelOwnerTenantNamespace: owner.GetNamespace(),
+		stewardv1alpha1.LabelOwnerPipelineRunName: owner.GetName(),
+	})
+}

--- a/pkg/stewardlabels/labelling_test.go
+++ b/pkg/stewardlabels/labelling_test.go
@@ -1,0 +1,287 @@
+package stewardlabels
+
+import (
+	"fmt"
+	"testing"
+
+	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	"github.com/mohae/deepcopy"
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type LabelAsSystemManagedTestCase struct {
+	// fields must be exported to make deepcopy work
+	PreexistingLabels    map[string]string
+	ExpectedResultLabels map[string]string
+}
+
+type LabelAsSystemManagedTestCases []LabelAsSystemManagedTestCase
+
+func (testcases LabelAsSystemManagedTestCases) run(t *testing.T, namePrefix string) {
+	t.Helper()
+
+	for idx, tc := range testcases {
+		t.Run(fmt.Sprintf("%s%d", namePrefix, idx), func(t *testing.T) {
+			t.Helper()
+
+			tc := deepcopy.Copy(tc).(LabelAsSystemManagedTestCase)
+			t.Parallel()
+			logTestCaseSpec(t, tc)
+
+			// SETUP
+			obj := &DummyObject1{}
+			obj.SetLabels(tc.PreexistingLabels)
+
+			// EXERCISE
+			LabelAsSystemManaged(obj)
+
+			// VERIFY
+			assert.DeepEqual(t, tc.ExpectedResultLabels, obj.GetLabels())
+
+			if tc.PreexistingLabels != nil {
+				assert.Assert(t, testableLabelMap(obj.GetLabels()).IsSameMapAs(tc.PreexistingLabels),
+					"label map of object has been replaced")
+			}
+		})
+	}
+}
+
+func Test__LabelAsSystemManaged(t *testing.T) {
+	const (
+		some1    = "some1key"
+		some1Val = "some1Val"
+	)
+
+	testcases := LabelAsSystemManagedTestCases{}
+
+	// cases without additional labels
+	{
+		expectedResultLabels := map[string]string{
+			stewardv1alpha1.LabelSystemManaged: "",
+		}
+
+		for _, preexistingLabels := range []map[string]string{
+			nil,
+			{},
+			{stewardv1alpha1.LabelSystemManaged: ""},
+			{stewardv1alpha1.LabelSystemManaged: "nonEmptyValue"},
+		} {
+			testcases = append(testcases, LabelAsSystemManagedTestCase{
+				PreexistingLabels:    preexistingLabels,
+				ExpectedResultLabels: expectedResultLabels,
+			})
+		}
+
+		// execute
+		testcases.run(t, "withoutAdditionalLabel/")
+	}
+
+	// cases with additional label
+	{
+		expectedResultLabels := map[string]string{
+			some1:                              some1Val,
+			stewardv1alpha1.LabelSystemManaged: "",
+		}
+
+		for _, existingLabels := range []map[string]string{
+			{
+				some1: some1Val,
+			},
+			{
+				some1:                              some1Val,
+				stewardv1alpha1.LabelSystemManaged: "",
+			},
+			{
+				some1:                              some1Val,
+				stewardv1alpha1.LabelSystemManaged: "nonEmptyValue",
+			},
+		} {
+			testcases = append(testcases, LabelAsSystemManagedTestCase{
+				PreexistingLabels:    existingLabels,
+				ExpectedResultLabels: expectedResultLabels,
+			})
+		}
+
+		// execute
+		testcases.run(t, "withAdditionalLabel/")
+	}
+}
+
+func Test__LabelAsSystemManaged__NilArg(t *testing.T) {
+	// EXERCISE
+	LabelAsSystemManaged(nil)
+}
+
+func Test__LabelAsOwnedByClientNamespace(t *testing.T) {
+	const (
+		ownerName = "owning-client-namespace-1"
+	)
+
+	// SETUP
+	obj := &DummyObject1{}
+
+	owner := &corev1.Namespace{}
+	owner.SetName(ownerName)
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByClientNamespace(obj, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+	expectedResultLabels := map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      ownerName,
+		stewardv1alpha1.LabelOwnerClientNamespace: ownerName,
+	}
+	assert.DeepEqual(t, expectedResultLabels, obj.GetLabels())
+}
+
+func Test__LabelAsOwnedByClientNamespace__NilArg__obj(t *testing.T) {
+	// SETUP
+	owner := &corev1.Namespace{}
+	owner.SetName("name1")
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByClientNamespace(nil, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+}
+
+func Test__LabelAsOwnedByClientNamespace__NilArg__owner(t *testing.T) {
+	// SETUP
+	obj := &DummyObject1{}
+	obj.SetName("name1")
+
+	// EXERCISE and VERIFY
+	assert.Assert(t, cmp.Panics(func() {
+		LabelAsOwnedByClientNamespace(obj, nil)
+	}))
+}
+
+func Test__LabelAsOwnedByTenant(t *testing.T) {
+	const (
+		ownerName       = "tenant-1"
+		ownerNamespace  = "client-namespace-1"
+		tenantNamespace = "tenant-1-namespace"
+	)
+
+	// SETUP
+	obj := &DummyObject1{}
+
+	owner := &stewardv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ownerName,
+			Namespace: ownerNamespace,
+		},
+		Status: stewardv1alpha1.TenantStatus{
+			TenantNamespaceName: tenantNamespace,
+		},
+	}
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByTenant(obj, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+
+	expectedResultLabels := map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      ownerNamespace,
+		stewardv1alpha1.LabelOwnerClientNamespace: ownerNamespace,
+		stewardv1alpha1.LabelOwnerTenantName:      ownerName,
+		stewardv1alpha1.LabelOwnerTenantNamespace: tenantNamespace,
+	}
+	assert.DeepEqual(t, expectedResultLabels, obj.GetLabels())
+}
+
+func Test__LabelAsOwnedByTenant__NilArg__obj(t *testing.T) {
+	// SETUP
+	owner := &stewardv1alpha1.Tenant{}
+	owner.SetName("name1")
+	owner.SetNamespace("namespace1")
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByTenant(nil, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+}
+
+func Test__LabelAsOwnedByTenant__NilArg__owner(t *testing.T) {
+	// SETUP
+	obj := &DummyObject1{}
+	obj.SetName("name1")
+
+	// EXERCISE and VERIFY
+	assert.Assert(t, cmp.Panics(func() {
+		LabelAsOwnedByTenant(obj, nil)
+	}))
+}
+
+func Test__LabelAsOwnedByPipelineRun(t *testing.T) {
+	const (
+		ownerName      = "pipelinerun-1"
+		ownerNamespace = "tenant-1-namespace"
+
+		tenantName = "tenant-1"
+
+		clientName      = "client-1-namespace"
+		clientNamespace = "client-1-namespace"
+	)
+
+	// SETUP
+	obj := &DummyObject1{}
+
+	owner := &stewardv1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ownerName,
+			Namespace: ownerNamespace,
+			Labels: map[string]string{
+				stewardv1alpha1.LabelOwnerClientName:      clientName,
+				stewardv1alpha1.LabelOwnerClientNamespace: clientNamespace,
+				stewardv1alpha1.LabelOwnerTenantName:      tenantName,
+			},
+		},
+	}
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByPipelineRun(obj, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+
+	expectedResultLabels := map[string]string{
+		stewardv1alpha1.LabelOwnerClientName:      clientName,
+		stewardv1alpha1.LabelOwnerClientNamespace: clientNamespace,
+		stewardv1alpha1.LabelOwnerTenantName:      tenantName,
+		stewardv1alpha1.LabelOwnerTenantNamespace: ownerNamespace,
+		stewardv1alpha1.LabelOwnerPipelineRunName: ownerName,
+	}
+	assert.DeepEqual(t, expectedResultLabels, obj.GetLabels())
+}
+
+func Test__LabelAsOwnedByPipelineRun__NilArg__obj(t *testing.T) {
+	// SETUP
+	owner := &stewardv1alpha1.PipelineRun{}
+	owner.SetName("name1")
+	owner.SetNamespace("namespace1")
+
+	// EXERCISE
+	resultErr := LabelAsOwnedByPipelineRun(nil, owner)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+}
+
+func Test__LabelAsOwnedByPipelineRun__NilArg__owner(t *testing.T) {
+	// SETUP
+	obj := &DummyObject1{}
+	obj.SetName("name1")
+
+	// EXERCISE and VERIFY
+	assert.Assert(t, cmp.Panics(func() {
+		LabelAsOwnedByPipelineRun(obj, nil)
+	}))
+}

--- a/pkg/stewardlabels/propagate.go
+++ b/pkg/stewardlabels/propagate.go
@@ -1,0 +1,101 @@
+package stewardlabels
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+/*
+propagate propagates specified labels from `sourceObj` to `destObj`,
+while values can be enforced for individual label keys.
+In case of a value conflict an error is returned and `destObj` is
+not modified.
+
+The set of labels to propagate is defined by the keys of `labelSpec`.
+A label value is enforced if the corresponding key in `labelSpec` is
+associated with a non-empty string value (empty values cannot be
+enforced).
+
+A value conflict exists for a label key if
+	a) the label value is enforced and the existing value at `sourceObj`
+	   differs from the enforced value, or
+	b) the label value is enforced and the exiting value at `destObj`
+	   differs from the enforced value, or
+    c) the existing values at `sourceObj` and `destObject` differ.
+The empty string value is NOT treated specially, e.g. there's a conflict
+if `destObj` has a label set with value "foo" but `sourceObj` has the
+same label set with an empty string value.
+
+If a value is enforced for a key, the label gets set on `destObj` even
+if `sourceObj` does not have that label set.
+If a value is not enforced and `sourceObj` has that label set, `destObj`
+get the same label set, except there is a value confict which leads to an
+error.
+If a value is not enforced and `sourceObj` does NOT have that label set,
+the respective label at `destObj` remains unchanged, i.e. will not be
+created, deleted or modified.
+*/
+func propagate(destObj metav1.Object, sourceObj metav1.Object, labelSpec map[string]string) error {
+	sourceLabels := sourceObj.GetLabels()
+
+	// fail if source has any value conflict with enforced value
+	for k, v := range labelSpec {
+		if v != "" { // value enforced
+			sourceValue, found := sourceLabels[k]
+			if found && sourceValue != v {
+				return fmt.Errorf(
+					"value conflict: source object label %q has value %q but %q is expected",
+					k, sourceValue, v,
+				)
+			}
+		}
+	}
+
+	destLabels := destObj.GetLabels()
+
+	// don't modify labels of dest object until propagation finished without errors
+	propagatedLabels := make(map[string]string)
+
+	// propagate
+	for k, v := range labelSpec {
+		if v == "" { // value not enforced
+			var foundOnSource bool
+			v, foundOnSource = sourceLabels[k]
+			if !foundOnSource {
+				// do not touch this label on dest object
+				continue
+			}
+		}
+		destValue, found := destLabels[k]
+		if found {
+			if destValue != v {
+				return fmt.Errorf(
+					"value conflict: destination object label %q has existing value %q but %q is expected",
+					k, destValue, v,
+				)
+			}
+		} else {
+			propagatedLabels[k] = v
+		}
+	}
+
+	// don't modify if nothing is propagated
+	if len(propagatedLabels) > 0 {
+		if destLabels == nil {
+			destObj.SetLabels(propagatedLabels)
+		} else {
+			for k, v := range propagatedLabels {
+				// Write into the same map we originally got from dest object
+				// so that we do not replace it in case it is dest object's
+				// internal label map
+				destLabels[k] = v
+			}
+			// because destLabels MAY NOT be dest object's internal label map
+			// but a copy or built from some other internal representation,
+			// we must call SetLabels() to ensure the update happens.
+			destObj.SetLabels(destLabels)
+		}
+	}
+	return nil
+}

--- a/pkg/stewardlabels/propagate_test.go
+++ b/pkg/stewardlabels/propagate_test.go
@@ -1,0 +1,508 @@
+package stewardlabels
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert/cmp"
+
+	"github.com/mohae/deepcopy"
+	"gotest.tools/assert"
+)
+
+type PropagateSuccessTestCase struct {
+	// fields must be exported to make deepcopy work
+
+	PreexistingDestLabels map[string]string
+	SourceLabels          map[string]string
+	LabelSpec             map[string]string
+
+	ExpectedResultLabels map[string]string
+}
+
+type PropagateSuccessTestCases []PropagateSuccessTestCase
+
+func (testcases PropagateSuccessTestCases) run(t *testing.T, namePrefix string) {
+	t.Helper()
+
+	for idx, tc := range testcases {
+		t.Run(fmt.Sprintf("%s%d", namePrefix, idx), func(t *testing.T) {
+			t.Helper()
+
+			// deepcopy removes shared parts between test cases and between fields of single test cases
+			tc := deepcopy.Copy(tc).(PropagateSuccessTestCase)
+			t.Parallel()
+			logTestCaseSpec(t, tc)
+
+			// SETUP
+			destObj := &DummyObject1{}
+			destObj.SetLabels(tc.PreexistingDestLabels)
+
+			sourceObj := &DummyObject1{}
+			sourceObj.SetLabels(tc.SourceLabels)
+
+			// EXERCISE
+			resultErr := propagate(destObj, sourceObj, tc.LabelSpec)
+
+			// VERIFY
+			assert.NilError(t, resultErr)
+			assert.DeepEqual(t, tc.ExpectedResultLabels, destObj.GetLabels())
+
+			if tc.PreexistingDestLabels != nil {
+				assert.Assert(t, testableLabelMap(destObj.GetLabels()).IsSameMapAs(tc.PreexistingDestLabels),
+					"label map of destination object has been replaced")
+			}
+		})
+	}
+}
+
+func Test__propagate__noPropagationOrEnforcedValues(t *testing.T) {
+	const (
+		some1    = "some1key"
+		some1Val = "some1Val"
+
+		some2    = "some2key"
+		some2Val = "some2Val"
+
+		empty    = ""
+		emptyVal = "emptyVal"
+	)
+
+	testcases := PropagateSuccessTestCases{}
+
+	// cases without any propagation or enforced values
+	for _, destLabels := range []map[string]string{
+		nil,
+		{},
+		{
+			some1: some1Val + "-dest",
+		},
+		{
+			some1: some1Val + "-dest",
+			some2: some2Val + "-dest",
+		},
+		{
+			empty: emptyVal + "-dest",
+		},
+	} {
+		for _, sourceLabels := range []map[string]string{
+			nil,
+			{},
+			{
+				some1: some1Val,
+			},
+			{
+				some1: some1Val,
+				some2: some2Val,
+			},
+			{
+				empty: emptyVal,
+			},
+		} {
+			for _, labelSpec := range []map[string]string{
+				nil,
+				{},
+				{
+					"nonexistentKey1": "",
+				},
+			} {
+				testcases = append(testcases, PropagateSuccessTestCase{
+					PreexistingDestLabels: destLabels,
+					SourceLabels:          sourceLabels,
+					LabelSpec:             labelSpec,
+					ExpectedResultLabels:  destLabels, // unmodified
+				})
+			}
+		}
+	}
+
+	// execute
+	testcases.run(t, "")
+}
+
+func Test__propagate__Propagations(t *testing.T) {
+	const (
+		propa1    = "propa1Key"
+		propa1Val = "propa1Val"
+
+		propa2    = "propa2Key"
+		propa2Val = "propa2Val"
+
+		other1    = "other1Key"
+		other1Val = "other1Val"
+
+		empty    = ""
+		emptyVal = "emptyVal"
+	)
+
+	// cases without additional labels on destObj
+	{
+		testcases := PropagateSuccessTestCases{}
+
+		labelSpec := map[string]string{
+			propa1: "",
+			propa2: "",
+			empty:  "",
+		}
+		expectedDestLabels := map[string]string{
+			propa1: propa1Val,
+			propa2: propa2Val,
+			empty:  emptyVal,
+		}
+
+		for _, destLabels := range []map[string]string{
+			nil,
+			{},
+			{
+				propa1: propa1Val,
+			},
+			{
+				propa1: propa1Val,
+				propa2: propa2Val,
+			},
+			{
+				empty: emptyVal,
+			},
+		} {
+			for _, sourceLabels := range []map[string]string{
+				{
+					propa1: propa1Val,
+					propa2: propa2Val,
+					empty:  emptyVal,
+				},
+				{
+					propa1: propa1Val,
+					propa2: propa2Val,
+					empty:  emptyVal,
+					other1: other1Val,
+				},
+			} {
+				testcases = append(testcases, PropagateSuccessTestCase{
+					PreexistingDestLabels: destLabels,
+					SourceLabels:          sourceLabels,
+					LabelSpec:             labelSpec,
+					ExpectedResultLabels:  expectedDestLabels,
+				})
+			}
+		}
+
+		// execute
+		testcases.run(t, "WithoutAdditionalLabelInDestObj/")
+	}
+
+	// cases with additional nonpropagated label on destObj
+	{
+		testcases := PropagateSuccessTestCases{}
+
+		labelSpec := map[string]string{
+			propa1: "",
+			propa2: "",
+		}
+		expectedDestLabels := map[string]string{
+			propa1: propa1Val,
+			propa2: propa2Val,
+			other1: other1Val + "-dest",
+		}
+
+		for _, destLabels := range []map[string]string{
+			{
+				propa1: propa1Val,
+				other1: other1Val + "-dest",
+			},
+			{
+				propa1: propa1Val,
+				propa2: propa2Val,
+				other1: other1Val + "-dest",
+			},
+		} {
+			for _, sourceLabels := range []map[string]string{
+				{
+					propa1: propa1Val,
+					propa2: propa2Val,
+				},
+				{
+					propa1: propa1Val,
+					propa2: propa2Val,
+					other1: other1Val,
+				},
+			} {
+				testcases = append(testcases, PropagateSuccessTestCase{
+					PreexistingDestLabels: destLabels,
+					SourceLabels:          sourceLabels,
+					LabelSpec:             labelSpec,
+					ExpectedResultLabels:  expectedDestLabels,
+				})
+			}
+		}
+
+		// execute
+		testcases.run(t, "WithAdditionalLabelInDestObj/")
+	}
+}
+
+func Test__propagate__EnforcedValues(t *testing.T) {
+	const (
+		enfor1    = "enfor1Key"
+		enfor1Val = "enfor1Val"
+
+		enfor2    = "enfor2Key"
+		enfor2Val = "enfor2Val"
+
+		other1    = "other1Key"
+		other1Val = "other1Val"
+
+		empty    = ""
+		emptyVal = "emptyVal"
+	)
+
+	// cases without additional labels on destObj
+	{
+		testcases := PropagateSuccessTestCases{}
+
+		labelSpec := map[string]string{
+			enfor1: enfor1Val,
+			enfor2: enfor2Val,
+			empty:  emptyVal,
+		}
+		expectedDestLabels := map[string]string{
+			enfor1: enfor1Val,
+			enfor2: enfor2Val,
+			empty:  emptyVal,
+		}
+		for _, destLabels := range []map[string]string{
+			nil,
+			{},
+			{
+				enfor1: enfor1Val,
+			},
+			{
+				enfor1: enfor1Val,
+				enfor2: enfor2Val,
+			},
+			{
+				empty: emptyVal,
+			},
+		} {
+			for _, sourceLabels := range []map[string]string{
+				nil,
+				{},
+				{
+					other1: other1Val,
+				},
+				{
+					enfor1: enfor1Val,
+					other1: other1Val,
+				},
+				{
+					enfor1: enfor1Val,
+					enfor2: enfor2Val,
+					other1: other1Val,
+				},
+				{
+					empty: emptyVal,
+				},
+			} {
+				testcases = append(testcases, PropagateSuccessTestCase{
+					PreexistingDestLabels: destLabels,
+					SourceLabels:          sourceLabels,
+					LabelSpec:             labelSpec,
+					ExpectedResultLabels:  expectedDestLabels,
+				})
+			}
+		}
+
+		// execute
+		testcases.run(t, "WithoutAdditionalLabelInDestObj/")
+	}
+
+	// cases with additional nonpropagated label on destObj
+	{
+		testcases := PropagateSuccessTestCases{}
+
+		labelSpec := map[string]string{
+			enfor1: enfor1Val,
+			enfor2: enfor2Val,
+		}
+		expectedDestLabels := map[string]string{
+			enfor1: enfor1Val,
+			enfor2: enfor2Val,
+			other1: other1Val + "-dest",
+		}
+
+		for _, destLabels := range []map[string]string{
+			{
+				enfor1: enfor1Val,
+				other1: other1Val + "-dest",
+			},
+			{
+				enfor1: enfor1Val,
+				enfor2: enfor2Val,
+				other1: other1Val + "-dest",
+			},
+		} {
+			for _, sourceLabels := range []map[string]string{
+				nil,
+				{},
+				{
+					other1: other1Val,
+				},
+				{
+					enfor1: enfor1Val,
+					other1: other1Val,
+				},
+				{
+					enfor1: enfor1Val,
+					enfor2: enfor2Val,
+					other1: other1Val,
+				},
+			} {
+				testcases = append(testcases, PropagateSuccessTestCase{
+					PreexistingDestLabels: destLabels,
+					SourceLabels:          sourceLabels,
+					LabelSpec:             labelSpec,
+					ExpectedResultLabels:  expectedDestLabels,
+				})
+			}
+		}
+
+		// execute
+		testcases.run(t, "WithAdditionalLabelInDestObj/")
+	}
+}
+
+type PropagateFailsTestCase struct {
+	// fields must be exported to make deepcopy work
+
+	DestLabels   map[string]string
+	SourceLabels map[string]string
+	LabelSpec    map[string]string
+
+	ExpectedErrorMsg string
+}
+
+type PropagateFailsTestCases []PropagateFailsTestCase
+
+func (testcases PropagateFailsTestCases) run(t *testing.T) {
+	t.Helper()
+
+	for idx, tc := range testcases {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Helper()
+
+			tc := deepcopy.Copy(tc).(PropagateFailsTestCase)
+			t.Parallel()
+			logTestCaseSpec(t, tc)
+
+			// SETUP
+			destLabels := deepcopy.Copy(tc.DestLabels).(map[string]string)
+			destObj := &DummyObject1{}
+			destObj.SetLabels(destLabels)
+
+			sourceObj := &DummyObject1{}
+			sourceObj.SetLabels(tc.SourceLabels)
+
+			// EXERCISE
+			resultErr := propagate(destObj, sourceObj, tc.LabelSpec)
+
+			// VERIFY
+			assert.Error(t, resultErr, tc.ExpectedErrorMsg)
+			assert.Assert(t, cmp.DeepEqual(tc.DestLabels, destObj.GetLabels()),
+				"labels have been modified")
+			if destLabels != nil {
+				assert.Assert(t, testableLabelMap(destObj.GetLabels()).IsSameMapAs(destLabels),
+					"label map of destination object has been replaced")
+			}
+		})
+	}
+}
+
+func expectedErrorMessageForValueConflictAtDestObj(labelKey, existingValue, expectedValue string) string {
+	return fmt.Sprintf(
+		"value conflict: destination object label %q has existing value %q but %q is expected",
+		labelKey, existingValue, expectedValue,
+	)
+}
+
+func expectedErrorMessageForValueConflictAtSourceObj(labelKey, existingValue, expectedValue string) string {
+	return fmt.Sprintf(
+		"value conflict: source object label %q has value %q but %q is expected",
+		labelKey, existingValue, expectedValue,
+	)
+}
+
+func Test__propagate__Fails_ValueConflictOnDestObj_FromPropagation(t *testing.T) {
+	const (
+		conflict1    = "conflict1Key"
+		conflict1Val = "conflict1Val"
+	)
+
+	testcases := PropagateFailsTestCases{}
+
+	testcases = append(testcases, PropagateFailsTestCase{
+		DestLabels: map[string]string{
+			conflict1: conflict1Val + "-dest",
+		},
+		SourceLabels: map[string]string{
+			conflict1: conflict1Val + "-source",
+		},
+		LabelSpec: map[string]string{
+			conflict1: "",
+		},
+
+		ExpectedErrorMsg: expectedErrorMessageForValueConflictAtDestObj(
+			conflict1, conflict1Val+"-dest", conflict1Val+"-source",
+		),
+	})
+
+	testcases.run(t)
+}
+
+func Test__propagate__Fails_ValueConflictOnDestObj_FromEnforcedValue(t *testing.T) {
+	const (
+		conflict1    = "conflict1Key"
+		conflict1Val = "conflict1Val"
+	)
+
+	testcases := PropagateFailsTestCases{}
+
+	testcases = append(testcases, PropagateFailsTestCase{
+		DestLabels: map[string]string{
+			conflict1: conflict1Val,
+		},
+		SourceLabels: nil,
+		LabelSpec: map[string]string{
+			conflict1: conflict1Val + "-enforced",
+		},
+
+		ExpectedErrorMsg: expectedErrorMessageForValueConflictAtDestObj(
+			conflict1, conflict1Val, conflict1Val+"-enforced",
+		),
+	})
+
+	testcases.run(t)
+}
+
+func Test__propagate__Fails_ValueConflictOnSourceObj(t *testing.T) {
+	const (
+		conflict1    = "conflict1Key"
+		conflict1Val = "conflict1Val"
+	)
+
+	testcases := PropagateFailsTestCases{}
+
+	testcases = append(testcases, PropagateFailsTestCase{
+		DestLabels: nil,
+		SourceLabels: map[string]string{
+			conflict1: conflict1Val,
+		},
+		LabelSpec: map[string]string{
+			conflict1: conflict1Val + "-enforced",
+		},
+
+		ExpectedErrorMsg: expectedErrorMessageForValueConflictAtSourceObj(
+			conflict1, conflict1Val, conflict1Val+"-enforced",
+		),
+	})
+
+	testcases.run(t)
+}

--- a/pkg/stewardlabels/zzz_utils_for_test.go
+++ b/pkg/stewardlabels/zzz_utils_for_test.go
@@ -1,0 +1,54 @@
+package stewardlabels
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/uuid"
+	"gotest.tools/assert/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DummyObject1 struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func logTestCaseSpec(t *testing.T, spec interface{}) {
+	t.Helper()
+
+	spewConf := &spew.ConfigState{
+		Indent:                  "\t",
+		DisableCapacities:       true,
+		DisablePointerAddresses: true,
+	}
+	t.Logf("Testcase:\n%s", spewConf.Sdump(spec))
+}
+
+type testableLabelMap map[string]string
+
+func (actual testableLabelMap) IsSameMapAs(expected map[string]string) cmp.Comparison {
+	return func() cmp.Result {
+		if result := cmp.DeepEqual(expected, map[string]string(actual))(); !result.Success() {
+			return result
+		}
+
+		if expected == nil && actual != nil {
+			return cmp.ResultFailure("expected nil but was not nil")
+		}
+
+		// Cannot test directly whether two maps reference the same map
+		// object internally (A == B is not allowed).
+		// Test indirectly by inserting into A and expecting to see it in B.
+		if expected != nil {
+			testKey := uuid.New().String()
+			expected[testKey] = testKey
+			found := actual[testKey] == testKey
+			delete(expected, testKey)
+			if !found {
+				return cmp.ResultFailure("maps are not the same")
+			}
+		}
+		return cmp.ResultSuccess
+	}
+}

--- a/pkg/tenantctl/controller.go
+++ b/pkg/tenantctl/controller.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	listers "github.com/SAP/stewardci-core/pkg/client/listers/steward/v1alpha1"
 	k8s "github.com/SAP/stewardci-core/pkg/k8s"
+	slabels "github.com/SAP/stewardci-core/pkg/stewardlabels"
 	utils "github.com/SAP/stewardci-core/pkg/utils"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -523,14 +524,11 @@ func (c *Controller) reconcileTenantRoleBinding(tenant *api.Tenant, namespace st
 func (c *Controller) generateTenantRoleBinding(
 	tenantNamespace string, clientNamespace string, config clientConfig,
 ) *rbacv1beta1.RoleBinding {
-	return &rbacv1beta1.RoleBinding{
+	roleBinding := &rbacv1beta1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			// let the server generate a unique name
 			GenerateName: tenantNamespaceRoleBindingNamePrefix,
 			Namespace:    tenantNamespace,
-			Labels: map[string]string{
-				api.LabelSystemManaged: "",
-			},
 		},
 		RoleRef: rbacv1beta1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -555,6 +553,10 @@ func (c *Controller) generateTenantRoleBinding(
 			},
 		},
 	}
+
+	slabels.LabelAsSystemManaged(roleBinding)
+
+	return roleBinding
 }
 
 func (c *Controller) isTenantRoleBindingUpToDate(current *rbacv1beta1.RoleBinding, expected *rbacv1beta1.RoleBinding) bool {


### PR DESCRIPTION
<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->

So far for the execution of a single pipeline run a single pipeline run sandbox namespace was used, which encapsulated all the resource objects needed during the execution. The sandbox namespace is an untrusted zone, as user-provided code has access to its contents, e.g. pods and secrets.

With pipeline run log forwarders we plan to deploy an additional service per pipeline run. That service is configured according to the needs of the "owning" pipeline run. The untrusted pipeline code may interact with the service, but must not have access to its configuration, pods, secrets and so on. Obviously such additional services cannot be defined in the pipeline run sandbox namespace.

Therefore, for each pipeline run an auxiliary namespace gets created next to the main sandbox namespace.

This change just introduces the creation of pipeline run auxiliary namespaces and changes the naming scheme for those. By default auxiliary namespaces are not created because they are not used yet. Enabling the feature flag `CreateAuxNamespaceIfUnused` enforces creating auxiliary namespaces.

### Dependency release notes

<!-- add links to release notes if important dependencies changed -->
N/A

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] with upgrade notes are prepared and appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
  - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- n/a Links to external changelogs added since the last release of our component
- n/a Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- n/a Check if dependency update affects our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] 'Upgrade notes' are documented in changelog.yaml (if required)
- [x] [changelog.yaml] entry for this Pull Request has been added
  - [x] Changelog entry contains all required information

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
