### PR TITLE
add feature flag support

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,11 +3,15 @@ Upstream-Name: github.com/SAP/stewardci-core
 Upstream-Contact: roman.isbrecht_at_sap.com
 Source: github.com/SAP/stewardci-core
 
-Files: **
+Files: *
 Copyright: 2019-2020 SAP SE or an SAP affiliate company and project "Steward" contributors
 License: Apache-2.0
 
-Files: pkg/runctl/controller.go pkg/tenantctl/controller.go
-Copyright: The Kubernetes Authors. 
-Modifications Copyright SAP SE 2020. All rights reserved.
+Files:
+ pkg/featureflag/types_test.go
+ pkg/featureflag/types.go
+ pkg/runctl/controller.go
+ pkg/tenantctl/controller.go
+Copyright: The Kubernetes Authors.
+ Modifications Copyright SAP SE 2020. All rights reserved.
 License: Apache-2.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -21,6 +21,15 @@
 - version: "NEXT"
   date: TBD
   changes:
+  - title: Introduce feature flags
+    type: internal
+    impact: patch
+    description: >-
+      There's a new Go package `pkg/featureflag` to deal
+      with feature flags in Steward controllers.
+      Feature flags can be configured via Helm Chart.
+    pullRequestNumber: 178
+
   - type: enhancement
     impact: incompatible
     title: Make Jenkinsfile Runner properties configurable in PipelineRun custom resource objects.

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -24,7 +24,7 @@
   - title: Introduce feature flags
     type: internal
     impact: patch
-    description: >-
+    description: |-
       There's a new Go package `pkg/featureflag` to deal
       with feature flags in Steward controllers.
       Feature flags can be configured via Helm Chart.

--- a/charts/steward/templates/deployment-run-controller.yaml
+++ b/charts/steward/templates/deployment-run-controller.yaml
@@ -46,6 +46,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
+        - name: STEWARD_FEATURE_FLAGS
+          value: {{ .Values.featureFlags | quote }}
         ports:
           - name: http-metrics
             containerPort: 9090

--- a/charts/steward/templates/deployment-tenant-controller.yaml
+++ b/charts/steward/templates/deployment-tenant-controller.yaml
@@ -44,6 +44,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
+        - name: STEWARD_FEATURE_FLAGS
+          value: {{ .Values.featureFlags | quote }}
         ports:
           - name: http-metrics
             containerPort: 9090

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -111,3 +111,5 @@ hooks:
       repository: docker.io/bitnami/kubectl
       tag: "1.17"
       pullPolicy: IfNotPresent
+
+featureFlags: ""

--- a/pkg/featureflag/flags.go
+++ b/pkg/featureflag/flags.go
@@ -1,0 +1,6 @@
+package featureflag
+
+var (
+	// Dummy shows how to define a feature flag. DO NOT USE IT!
+	Dummy = New("Dummy", Bool(false))
+)

--- a/pkg/featureflag/testing/testing.go
+++ b/pkg/featureflag/testing/testing.go
@@ -1,0 +1,43 @@
+/*
+Package testing provides utilities for tests that depend on
+feature flags.
+
+Feature flags are shared state. When tests change feature flags,
+they must ensure that no other tests are affected.
+
+1. They must restore the default feature flag state when the
+   test is finished.
+
+2. They must not run in parallel with other tests that could be
+   affected by changed feature flags state.
+*/
+package testing
+
+import "github.com/SAP/stewardci-core/pkg/featureflag"
+
+/*
+WithFeatureFlag sets the given feature flag to the given state and
+returns a reset function to revert to the previous feature flag state.
+
+The returned function is meant to be called deferred by the caller.
+
+Example:
+
+    defer testing.WithFeatureFlag(featureflag.Dummy, true)()
+*/
+func WithFeatureFlag(ff *featureflag.FeatureFlag, enabled bool) func() {
+	changeFeatureFlag := func(ff *featureflag.FeatureFlag, enabled bool) {
+		flagstr := ""
+		if !enabled {
+			flagstr = "-"
+		}
+		flagstr += ff.Key
+		featureflag.ParseFlags(flagstr)
+	}
+
+	orig := ff.Enabled()
+	changeFeatureFlag(ff, enabled)
+	return func() {
+		changeFeatureFlag(ff, orig)
+	}
+}

--- a/pkg/featureflag/types.go
+++ b/pkg/featureflag/types.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package featureflag implements simple feature-flagging.
+Feature flags can become an anti-pattern if abused.
+We should try to use them for two use-cases:
+- `Preview` feature flags enable a piece of functionality we haven't yet fully baked.  The user needs to 'opt-in'.
+  We expect these flags to be removed at some time.  Normally these will default to false.
+- Escape-hatch feature flags turn off a default that we consider risky (e.g. pre-creating DNS records).
+  This lets us ship a behaviour, and if we encounter unusual circumstances in the field, we can
+  allow the user to turn the behaviour off.  Normally these will default to true.
+
+Feature flags are set via a single environment variable.
+The value is a string of feature flag keys separated by sequences of
+whitespace and comma.
+Each key can be prefixed with `+` (enable flag) or `-` (disable flag).
+Without prefix the flag gets enabled.
+*/
+package featureflag
+
+import (
+	"os"
+	"regexp"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// Name is the name of the environment variable which encapsulates feature flags.
+	Name = "STEWARD_FEATURE_FLAGS"
+)
+
+func init() {
+	ParseFlags(os.Getenv(Name))
+}
+
+var (
+	flags      = make(map[string]*FeatureFlag)
+	flagsMutex sync.Mutex
+)
+
+// FeatureFlag defines a feature flag
+type FeatureFlag struct {
+	Key          string
+	enabled      *bool
+	defaultValue *bool
+}
+
+// New creates a new feature flag.
+func New(key string, defaultValue *bool) *FeatureFlag {
+	flagsMutex.Lock()
+	defer flagsMutex.Unlock()
+
+	f := flags[key]
+	if f == nil {
+		f = &FeatureFlag{
+			Key: key,
+		}
+		flags[key] = f
+	}
+
+	if f.defaultValue == nil {
+		f.defaultValue = defaultValue
+	}
+
+	return f
+}
+
+// Enabled checks if the flag is enabled.
+func (f *FeatureFlag) Enabled() bool {
+	if f.enabled != nil {
+		return *f.enabled
+	}
+	if f.defaultValue != nil {
+		return *f.defaultValue
+	}
+	return false
+}
+
+// Bool returns a pointer to the boolean value.
+func Bool(b bool) *bool {
+	return &b
+}
+
+// ParseFlags is responsible for parse out the feature flag usage.
+func ParseFlags(f string) {
+	if f == "" {
+		return
+	}
+	for _, s := range regexp.MustCompile(`[[:space:],]+`).Split(f, -1) {
+		if s == "" {
+			continue
+		}
+		enabled := true
+		var ff *FeatureFlag
+		if s[0] == '+' || s[0] == '-' {
+			ff = New(s[1:], nil)
+			if s[0] == '-' {
+				enabled = false
+			}
+		} else {
+			ff = New(s, nil)
+		}
+		klog.InfoS("feature flag", "key", ff.Key, "enabled", enabled)
+		ff.enabled = &enabled
+	}
+}

--- a/pkg/featureflag/types_test.go
+++ b/pkg/featureflag/types_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featureflag
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestFlagToFalse(t *testing.T) {
+	f := New("UnitTest1", Bool(true))
+	if !f.Enabled() {
+		t.Fatalf("Flag did not default true")
+	}
+
+	// Really just to force a dependency on glog, so that we can pass -v and -logtostderr to go test
+	klog.Info("Created flag Unittest1")
+
+	ParseFlags("-UnitTest1")
+	if f.Enabled() {
+		t.Fatalf("Flag did not default turn off")
+	}
+
+	ParseFlags("UnitTest1")
+	if !f.Enabled() {
+		t.Fatalf("Flag did not default turn on")
+	}
+}
+
+func TestSetenv(t *testing.T) {
+	f := New("UnitTest2", Bool(true))
+	if !f.Enabled() {
+		t.Fatalf("Flag did not default true")
+	}
+
+	os.Setenv("STEWARD_FEATURE_FLAGS", "-UnitTest2")
+	if !f.Enabled() {
+		t.Fatalf("Flag was reparsed immediately after os.Setenv")
+	}
+
+	ParseFlags("-UnitTest2")
+	if f.Enabled() {
+		t.Fatalf("Flag was not updated by ParseFlags")
+	}
+}


### PR DESCRIPTION
- Go package to define and check feature flags
- Helm chart enhancement: inject feature flags into controllers
  via environment variable

The Go implementation is based on [kops' featureflag package][1].

[1]: https://github.com/kubernetes/kops/tree/v1.18.1/pkg/featureflag

### Dependency release notes

No dependency changes.

### Submitter checklist

- [ ] N/A Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] with upgrade notes are prepared and appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
  - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] N/A Links to external changelogs added since the last release of our component
- [ ] N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] N/A Check if dependency update affects our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least one approval for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] 'Upgrade notes' are documented in changelog.yaml (if required)
- [x] [changelog.yaml] entry for this Pull Request has been added
  - [x] Changelog entry contains all required information

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
