### PR TITLE
fix: struct tag not compatible with reflect.StructTag

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -21,7 +21,15 @@
 - version: "NEXT"
   date: TBD
   changes:
-
+  - type: bug
+    impact: patch
+    title: Fix struct field tag syntax for "pkg/apis/steward/v1alpha1".JenkinsfileRunnerSpec
+    description:
+    warning:
+    upgradeNotes:
+    deprecations:
+    pullRequestNumber: 186
+    jiraIssueNumber:
 - version: "0.6.1"
   date: 2020-11-11
   changes:

--- a/pkg/apis/steward/v1alpha1/run_types.go
+++ b/pkg/apis/steward/v1alpha1/run_types.go
@@ -84,7 +84,7 @@ type JenkinsfileRunnerSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// ImagePullPolicy is the pull policy for the image
-	ImagePullPolicy string `json:imagePullPolicy,omitempty`
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 }
 
 // JenkinsFile represents the location from where to get the pipeline


### PR DESCRIPTION
### Description

Fix struct field tag syntax for `"pkg/apis/steward/v1alpha1".JenkinsfileRunnerSpec`

### Dependency release notes

<!-- add links to release notes if important dependencies changed -->
N/A

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] with upgrade notes are prepared and appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs added since the last release of our component
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency update affects our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least one approval for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] 'Upgrade notes' are documented in changelog.yaml (if required)
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
