### PR TITLE
Delete finalizer when pipeline run is cleaned

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,15 @@
 - version: NEXT
   date: TBD
   changes:
+  - type: bug
+    impact: patch
+    title: Delete finalizer after pipeline run is cleaned.
+    description: |-
+      Delete finalizer after pipeline run is cleaned.
+    warning:
+    deprecations:
+    pullRequestNumber: 210
+    jiraIssueNumber: 413
 
   - type: enhancement
     impact: minor

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/SAP/stewardci-core/pkg/metrics"
 	"github.com/SAP/stewardci-core/pkg/runctl/cfg"
 	run "github.com/SAP/stewardci-core/pkg/runctl/run"
+	utils "github.com/SAP/stewardci-core/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -244,8 +245,14 @@ func (c *Controller) syncHandler(key string) error {
 		return nil
 	}
 	// fast exit
-	if pipelineRunAPIObj.Status.State == api.StateFinished && pipelineRunAPIObj.GetDeletionTimestamp().IsZero() {
-		return nil
+	if pipelineRunAPIObj.GetDeletionTimestamp().IsZero() {
+		if pipelineRunAPIObj.Status.State == api.StateFinished {
+			return nil
+		}
+	} else {
+		if !utils.StringSliceContains(pipelineRunAPIObj.ObjectMeta.Finalizers, k8s.FinalizerName) {
+			return nil
+		}
 	}
 
 	// Get real pipelineRun bypassing cache

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -352,6 +352,12 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				if test.expectedMessage != "" {
 					assert.Assert(t, is.Regexp(test.expectedMessage, result.Status.Message))
 				}
+
+				if test.expectedState == api.StateFinished {
+					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 0)
+				} else {
+					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 1)
+				}
 			})
 		}
 	}
@@ -618,6 +624,12 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 
 				if test.expectedMessage != "" {
 					assert.Assert(t, is.Regexp(test.expectedMessage, result.Status.Message))
+				}
+
+				if test.expectedState == api.StateFinished {
+					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 0)
+				} else {
+					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 1)
 				}
 			})
 		}

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -169,14 +169,6 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 			expectedError:     false,
 			expectedFinalizer: false,
 		},
-		{name: "delete without finalizer ok",
-			runManagerExpectation: func(rm *runmocks.MockManager) {
-				rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
-			},
-			hasFinalizer:      false,
-			expectedError:     false,
-			expectedFinalizer: false,
-		},
 		{name: "delete with finalizer fail",
 			runManagerExpectation: func(rm *runmocks.MockManager) {
 				rm.EXPECT().Cleanup(gomock.Any()).Return(fmt.Errorf("expected"))
@@ -185,14 +177,11 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 			expectedError:     true,
 			expectedFinalizer: true,
 		},
-		{name: "delete without finalizer fail",
-			runManagerExpectation: func(rm *runmocks.MockManager) {
-				rm.EXPECT().Cleanup(gomock.Any()).Return(fmt.Errorf("expected"))
-			},
-			hasFinalizer:      false,
-			expectedError:     true,
-			expectedFinalizer: false, // TODO: is this the correct expect here?
-
+		{name: "delete without finalizer already done",
+			runManagerExpectation: func(rm *runmocks.MockManager) {},
+			hasFinalizer:          false,
+			expectedError:         false,
+			expectedFinalizer:     false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
### Description

Remove finalizer from pipeline run when cleaning step is done. This avoids delays in deleting pipeline run objects, especially when deleting many of them at the same time, e.g. in test systems.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information
    - [x] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
