### PR TITLE
fix tenant reconcile issue

### DIFF
--- a/pkg/tenantctl/controller_test.go
+++ b/pkg/tenantctl/controller_test.go
@@ -168,11 +168,14 @@ func Test_Controller_syncHandler_UninitializedTenant_GoodCase(t *testing.T) {
 	ctl := NewController(cf, NewMetrics())
 	ctl.fetcher = k8s.NewClientBasedTenantFetcher(cf)
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
-
-	// VERIFY
 	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
 	tenant, err := cf.StewardV1alpha1().Tenants(clientNSName).Get(tenantID, metav1.GetOptions{})
 	assert.NilError(t, err)
 
@@ -257,8 +260,12 @@ func Test_Controller_syncHandler_UninitializedTenant_FailsOnNamespaceClash(t *te
 	ctl := NewController(cf, NewMetrics())
 	ctl.fetcher = k8s.NewClientBasedTenantFetcher(cf)
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
@@ -323,8 +330,12 @@ func Test_Controller_syncHandler_UninitializedTenant_FailsOnErrorWhenSyncingRole
 		},
 	}
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
@@ -379,8 +390,12 @@ func Test_Controller_syncHandler_InitializedTenant_AddsMissingRoleBinding(t *tes
 	ctl := NewController(cf, NewMetrics())
 	ctl.fetcher = k8s.NewClientBasedTenantFetcher(cf)
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.NilError(t, resultErr)
@@ -464,8 +479,12 @@ func Test_Controller_syncHandler_InitializedTenant_FailsOnMissingNamespace(t *te
 	ctl := NewController(cf, NewMetrics())
 	ctl.fetcher = k8s.NewClientBasedTenantFetcher(cf)
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
@@ -534,8 +553,12 @@ func Test_Controller_syncHandler_InitializedTenant_FailsOnErrorWhenSyncingRoleBi
 		},
 	}
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
@@ -595,8 +618,12 @@ func Test_Controller_syncHandler_CleanupOnDelete_IfFinalizerIsSet(t *testing.T) 
 
 	// initialize tenant
 	{
+		// EXERCISE - Add Finalizer
 		err := ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
+
+		// EXERCISE - Add Status.TenantNamespaceName
+		err = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
 		assert.NilError(t, err)
@@ -662,8 +689,12 @@ func Test_Controller_syncHandler_CleanupOnDelete_SkippedIfFinalizerIsNotSet(t *t
 
 	// initialize tenant
 	{
+		// EXERCISE - Add Finalizer
 		err := ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
+
+		// EXERCISE - Add Status.TenantNamespaceName
+		err = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
 		assert.NilError(t, err)
@@ -731,8 +762,12 @@ func Test_Controller_syncHandler_CleanupOnDelete_IfNamespaceDoesNotExistAnymore(
 
 	// initialize tenant
 	{
+		// EXERCISE - Add Finalizer
 		err := ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
+
+		// EXERCISE - Add Status.TenantNamespaceName
+		err = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
 		assert.NilError(t, err)
@@ -808,8 +843,12 @@ func Test_Controller_syncHandler_CleanupOnStatusUpdateFailure(t *testing.T) {
 		},
 	}
 
-	// EXERCISE
+	// EXERCISE - Add Finalizer
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	assert.NilError(t, resultErr)
+
+	// EXERCISE - Add Status.TenantNamespaceName
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, injectedError == resultErr)


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->

This PR is to fix the issue https://github.com/SAP/stewardci-core/issues/152.
After investigation, the root cause of the issue is that two events (`onAdd` and `onUpdate`) were triggered before the creation of the corresponding `namespace`.

When one tenant is added, another update event would be triggered after the execution of this line https://github.com/SAP/stewardci-core/blob/master/pkg/tenantctl/controller.go#L217, which will cause next round reconcile process, however at that time, `namespace` has not been created, and `Status.TenantNamespaceName == nil`. So in race condition will happen when two go routines are executing the `syncHandler` method.

In my opinion, it is better to update resources (`tenant`) once in each reconcile process, otherwise, it probably will cause failing to update resources because mismatch of `resourceVersion`.

Because after the change, two reconcile processes are needed (one to add `Finalizers` and the other to add `Status.TenantNamespaceName`) to add one tenant, so also modify the unit test cases.

Please correct me if my logic is wrong. Thanks a lot.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
