### PR TITLE
fix args qps and burst of tenant contr deployment

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -54,7 +54,7 @@
   
   - type: bug
     impact: patch
-    title: Delete finalizer after pipeline run is cleaned.
+    title: fix args qps and burst of tenant controller deployment
     description: |-
       fix use qps and burst of tenant controller from the corresponding config values and not from run controller configuration
     warning:

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,16 @@
 - version: NEXT
   date: TBD
   changes:
+  
+  - type: bug
+    impact: patch
+    title: Delete finalizer after pipeline run is cleaned.
+    description: |-
+      fix use qps and burst of tenant controller from the corresponding config values and not from run controller configuration
+    warning:
+    deprecations:
+    pullRequestNumber: 218
+    jiraIssueNumber: 214
 
 - version: "0.8.0"
   date: 2021-02-19

--- a/charts/steward/templates/deployment-tenant-controller.yaml
+++ b/charts/steward/templates/deployment-tenant-controller.yaml
@@ -34,8 +34,8 @@ spec:
         imagePullPolicy: {{ .pullPolicy | quote }}
         {{- end }}
         args:
-        - {{ printf "-qps=%d" ( .Values.runController.args.qps | int ) | quote }}
-        - {{ printf "-burst=%d" ( .Values.runController.args.burst | int ) | quote }}
+        - {{ printf "-qps=%d" ( .Values.tenantController.args.qps | int ) | quote }}
+        - {{ printf "-burst=%d" ( .Values.tenantController.args.burst | int ) | quote }}
         - {{ printf "-threadiness=%d" ( .Values.tenantController.args.threadiness | int ) | quote }}
         {{- if .Values.tenantController.args.logVerbosity }}
         - {{ printf "-v=%d" ( .Values.tenantController.args.logVerbosity | int ) | quote }}


### PR DESCRIPTION
### Description
took the wrong value (from run controller) as qps and burst in tenant controller

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
