### PR TITLE
Fix checkmarx findings

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,13 @@
   date: TBD
   changes:
 
+  - type: internal
+    impact: patch
+    title: Fixed checkmarx scan
+    description: |-
+      The checkmarks scan reported some low findings which are fixed now.
+    pullRequestNumber: 223
+
   - type: security
     impact: patch
     title: Update JFR image to 210413_777e270 with secure agent protocols

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -285,7 +285,8 @@ func (r *pipelineRun) HasDeletionTimestamp() bool {
 func (r *pipelineRun) AddFinalizer() error {
 	changed, finalizerList := utils.AddStringIfMissing(r.apiObj.ObjectMeta.Finalizers, FinalizerName)
 	if changed {
-		r.updateFinalizers(finalizerList)
+		err := r.updateFinalizers(finalizerList)
+		return err
 	}
 	return nil
 }

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -300,7 +300,10 @@ func (c *Controller) syncHandler(key string) error {
 
 	// As soon as we have a result we can cleanup
 	if pipelineRun.GetStatus().Result != api.ResultUndefined && pipelineRun.GetStatus().State != api.StateCleaning {
-		c.changeState(pipelineRun, api.StateCleaning)
+		err = c.changeState(pipelineRun, api.StateCleaning)
+		if err != nil {
+			klog.V(1).Infof("WARN: change state to cleaning failed with: %s", err.Error())
+		}
 	}
 
 	if pipelineRun.GetStatus().State == api.StateNew {

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -508,7 +508,7 @@ func (c *runManager) createTektonTaskRun(ctx *runContext) error {
 	c.addTektonTaskRunParamsForJenkinsfileRunnerImage(ctx, &tektonTaskRun)
 	err = c.addTektonTaskRunParamsForPipeline(ctx, &tektonTaskRun)
 	if err != nil {
-		return serrors.Classify(err, stewardv1alpha1.ResultErrorInfra)
+		return serrors.Classify(err, stewardv1alpha1.ResultErrorConfig)
 	}
 	err = c.addTektonTaskRunParamsForLoggingElasticsearch(ctx, &tektonTaskRun)
 	if err != nil {

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -145,7 +145,7 @@ func (c *runManager) prepareRunNamespace(ctx *runContext) error {
 	// If something goes wrong while creating objects inside the namespaces, we delete everything.
 	cleanupOnError := func() {
 		if err != nil {
-			c.cleanup(ctx)
+			_ = c.cleanup(ctx)
 		}
 	}
 	defer cleanupOnError()
@@ -506,7 +506,10 @@ func (c *runManager) createTektonTaskRun(ctx *runContext) error {
 		},
 	}
 	c.addTektonTaskRunParamsForJenkinsfileRunnerImage(ctx, &tektonTaskRun)
-	c.addTektonTaskRunParamsForPipeline(ctx, &tektonTaskRun)
+	err = c.addTektonTaskRunParamsForPipeline(ctx, &tektonTaskRun)
+	if err != nil {
+		return serrors.Classify(err, stewardv1alpha1.ResultErrorInfra)
+	}
 	err = c.addTektonTaskRunParamsForLoggingElasticsearch(ctx, &tektonTaskRun)
 	if err != nil {
 		return serrors.Classify(err, stewardv1alpha1.ResultErrorConfig)

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -145,7 +145,7 @@ func (c *runManager) prepareRunNamespace(ctx *runContext) error {
 	// If something goes wrong while creating objects inside the namespaces, we delete everything.
 	cleanupOnError := func() {
 		if err != nil {
-			_ = c.cleanup(ctx)
+			c.cleanup(ctx) // clean-up ignoring error
 		}
 	}
 	defer cleanupOnError()

--- a/pkg/tenantctl/controller.go
+++ b/pkg/tenantctl/controller.go
@@ -226,7 +226,7 @@ func (c *Controller) syncHandler(key string) error {
 	if !equality.Semantic.DeepEqual(origTenant.Status, tenant.Status) {
 		if _, err := c.updateStatus(tenant); err != nil {
 			if !c.isInitialized(origTenant) && c.isInitialized(tenant) {
-				_ = c.deleteTenantNamespace(tenant.Status.TenantNamespaceName, tenant, config) // clean-up ignoring error
+				c.deleteTenantNamespace(tenant.Status.TenantNamespaceName, tenant, config) // clean-up ignoring error
 			}
 			return err
 		}
@@ -278,7 +278,7 @@ func (c *Controller) reconcileUninitialized(config clientConfig, tenant *api.Ten
 			Reason:  api.StatusReasonFailed,
 			Message: condMsg,
 		})
-		_ = c.deleteTenantNamespace(nsName, tenant, config) // clean-up ignoring error
+		c.deleteTenantNamespace(nsName, tenant, config) // clean-up ignoring error
 		return err
 	}
 

--- a/pkg/tenantctl/controller.go
+++ b/pkg/tenantctl/controller.go
@@ -208,7 +208,7 @@ func (c *Controller) syncHandler(key string) error {
 		if err != nil {
 			return err
 		}
-		tenant, err = c.removeFinalizerAndUpdate(tenant) //TODO: static code check complains: "this value of tenant is never used (SA4006)go-staticcheck"
+		_, err = c.removeFinalizerAndUpdate(tenant)
 		if err == nil {
 			c.syncCount++
 		}


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
Our checkmarx scan failed with some low findings.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
