### PR TITLE
Do not create ns twice

### DIFF
--- a/pkg/k8s/namespaceManager.go
+++ b/pkg/k8s/namespaceManager.go
@@ -118,19 +118,19 @@ func (m *namespaceManager) generateName(customPart string) (string, error) {
 }
 
 func (m *namespaceManager) List(nameCustomPart string) ([]string, error) {
-	matchLables := map[string]string{
+	matchLabels := map[string]string{
 		labelPrefix: m.prefix,
 		labelID:     nameCustomPart,
 	}
 
 	namespaces, err := m.nsInterface.List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v", labels.Set(matchLables).String()),
+		LabelSelector: fmt.Sprintf("%v", labels.Set(matchLabels).String()),
 	})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}
-		err = errors.WithMessagef(err, "error: failed to list namespaces with label selector %v", matchLables)
+		err = errors.WithMessagef(err, "error: failed to list namespaces with label selector %v", matchLabels)
 		return nil, err
 	}
 

--- a/pkg/tenantctl/controller_test.go
+++ b/pkg/tenantctl/controller_test.go
@@ -174,6 +174,12 @@ func Test_Controller_syncHandler_UninitializedTenant_GoodCase(t *testing.T) {
 
 	// VERIFY
 	assert.NilError(t, resultErr)
+
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+
 	tenant, err := cf.StewardV1alpha1().Tenants(clientNSName).Get(tenantID, metav1.GetOptions{})
 	assert.NilError(t, err)
 
@@ -260,6 +266,10 @@ func Test_Controller_syncHandler_UninitializedTenant_FailsOnNamespaceClash(t *te
 
 	// EXERCISE
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	// VERIFY
+	assert.Assert(t, resultErr == nil)
+	// EXERCISE
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
@@ -328,6 +338,10 @@ func Test_Controller_syncHandler_UninitializedTenant_FailsOnErrorWhenSyncingRole
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 
 	// VERIFY
+	assert.Assert(t, resultErr == nil)
+	// EXERCISE
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
+	// VERIFY
 	assert.Assert(t, resultErr != nil)
 	assert.Assert(t, injectedError == resultErr)
 
@@ -380,7 +394,10 @@ func Test_Controller_syncHandler_InitializedTenant_AddsMissingRoleBinding(t *tes
 
 	// EXERCISE
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
-
+	// VERIFY
+	assert.NilError(t, resultErr)
+	// EXERCISE
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 	// VERIFY
 	assert.NilError(t, resultErr)
 	tenant, err := cf.StewardV1alpha1().Tenants(clientNSName).Get(tenantID, metav1.GetOptions{})
@@ -465,9 +482,13 @@ func Test_Controller_syncHandler_InitializedTenant_FailsOnMissingNamespace(t *te
 
 	// EXERCISE
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
-
+	// VERIFY
+	assert.Assert(t, resultErr == nil)
+	// EXERCISE
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
+
 	assert.Error(t, resultErr, fmt.Sprintf("tenant namespace \"%s\" does not exist anymore", tenantNSName))
 
 	tenant, err := cf.StewardV1alpha1().Tenants(clientNSName).Get(tenantID, metav1.GetOptions{})
@@ -535,7 +556,10 @@ func Test_Controller_syncHandler_InitializedTenant_FailsOnErrorWhenSyncingRoleBi
 
 	// EXERCISE
 	resultErr := ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
-
+	// VERIFY
+	assert.NilError(t, resultErr)
+	// EXERCISE
+	resultErr = ctl.syncHandler(makeTenantKey(clientNSName, tenantID))
 	// VERIFY
 	assert.Assert(t, resultErr != nil)
 	assert.Assert(t, injectedError == resultErr)
@@ -596,7 +620,8 @@ func Test_Controller_syncHandler_CleanupOnDelete_IfFinalizerIsSet(t *testing.T) 
 	{
 		err := ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
-
+		err = ctl.syncHandler(tenantKey)
+		assert.NilError(t, err)
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
 		assert.NilError(t, err)
 		tenantNSName = initializedTenant.Status.TenantNamespaceName
@@ -662,6 +687,8 @@ func Test_Controller_syncHandler_CleanupOnDelete_SkippedIfFinalizerIsNotSet(t *t
 	// initialize tenant
 	{
 		err := ctl.syncHandler(tenantKey)
+		assert.NilError(t, err)
+		err = ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
 
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
@@ -732,7 +759,8 @@ func Test_Controller_syncHandler_CleanupOnDelete_IfNamespaceDoesNotExistAnymore(
 	{
 		err := ctl.syncHandler(tenantKey)
 		assert.NilError(t, err)
-
+		err = ctl.syncHandler(tenantKey)
+		assert.NilError(t, err)
 		initializedTenant, err := tenantsIfc.Get(tenantID, metav1.GetOptions{})
 		assert.NilError(t, err)
 		tenantNSName = initializedTenant.Status.TenantNamespaceName
@@ -810,6 +838,9 @@ func Test_Controller_syncHandler_CleanupOnStatusUpdateFailure(t *testing.T) {
 
 	// EXERCISE
 	resultErr := ctl.syncHandler(tenantKey)
+	assert.NilError(t, resultErr)
+	// EXERCISE
+	resultErr = ctl.syncHandler(tenantKey)
 
 	// VERIFY
 	assert.Assert(t, injectedError == resultErr)


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->

In this PR, in tenant controller loop, we always check ns before it is created via labels. This is a common way to handle related resources, like Deployment and ReplicaSet. 


### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
