### PR TITLE
Warn about wrong usernamePassword secret type

### DIFF
--- a/docs/secrets/Secrets.md
+++ b/docs/secrets/Secrets.md
@@ -171,6 +171,8 @@ The given secrets are standard Kubernetes `v1/Secret` resource objects that must
 The Kubernetes Credentials Provider Plugin requires Secret resource objects to be of __certain types and carry special labels and annotations__ in order to map correctly them to Jenkins credential types.
 Details can be found on the [Examples page][jenkins_k8s_credential_provider_plugin_examples] of the plugin.
 
+__:warning: Warning:__ For usernamePassword credentials `type: Opaque` does not work, instead `type: kubernetes.io/basic-auth` is required.
+
 When a pipeline gets executed in a transient sandbox namespace, the secrets listed in `spec.secrets` of the corresponding PipelineRun resource object are copied to the sandbox namespace with the same name.
 It is also possible to rename the secret while it gets copied by providing the desired name as annotation `steward.sap.com/secret-rename-to` on the original secret. The desired name must be a valid Kubernetes Secret name and be unique within the sandbox namespace. In `spec.secrets` of pipeline runs the original secret name must be used to select secrets.
 The Jenkins Kubernetes Credentials Provider Plugin will use the secrets from the sandbox namespace only.


### PR DESCRIPTION
### Description

The secret yaml in the jenkinsci examples page shows the wrong secret type.

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
