### PR TITLE
[CLOUDCIFEAT1-130] Avoid non atomic updates

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -53,7 +53,7 @@
   changes:
 
     - type: bug
-      impact: patch
+      impact: minor
       title: Avoid non atomic status updates
       description: |-
         Without this change the state might be upated e.g. to a final state

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,20 @@
 - version: NEXT
   date: TBD
   changes:
+    - type: bug
+      impact: patch
+      title: Avoid non atomic status updates
+      description: |-
+        Without this change the state might be upated e.g. to a final state
+        without setting a corresponding result. The result is provided a short period
+        of time later with an other update. In the meantime we have an invalid state.
+        With this change we apply both changes to the memory representation of a
+        pipeline run and send the update only once. With this approach there is no
+        short period of time with an invalid state
+      warning: |-
+        needs to be validated carefully since this is a bigger refactoring
+      pullRequestNumber: 248
+      jiraIssueNumber: CLOUDCIFEAT1-130
 
 - version: "0.12.1"
   date: 2021-07-28

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,20 +52,20 @@
   date: TBD
   changes:
 
-    - type: bug
-      impact: minor
-      title: Avoid non atomic status updates
-      description: |-
-        Without this change the state might be upated e.g. to a final state
-        without setting a corresponding result. The result is provided a short period
-        of time later with an other update. In the meantime we have an invalid state.
-        With this change we apply both changes to the memory representation of a
-        pipeline run and send the update only once. With this approach there is no
-        short period of time with an invalid state
-      warning: |-
-        needs to be validated carefully since this is a bigger refactoring
-      pullRequestNumber: 248
-      jiraIssueNumber: CLOUDCIFEAT1-130
+     - type: bug
+       impact: minor
+       title: Avoid non atomic status updates
+       description: |-
+         Without this change the state might be upated e.g. to a final state
+         without setting a corresponding result. The result is provided a short period
+         of time later with an other update. In the meantime we have an invalid state.
+         With this change we apply both changes to the memory representation of a
+         pipeline run and send the update only once. With this approach there is no
+         short period of time with an invalid state
+       warning: |-
+         needs to be validated carefully since this is a bigger refactoring
+       pullRequestNumber: 248
+       jiraIssueNumber: CLOUDCIFEAT1-130
 
      - type: bug
        impact: patch

--- a/charts/steward/Chart.yaml
+++ b/charts/steward/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.12.2-dev
+version: 0.13.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.12.2-dev
+appVersion: 0.13.0-dev

--- a/pkg/apis/steward/v1alpha1/constants.go
+++ b/pkg/apis/steward/v1alpha1/constants.go
@@ -78,6 +78,10 @@ const (
 	// faces an intermittent error during running phase.
 	EventReasonRunningFailed = "RunningFailed"
 
+	// EventReasonCleaningFailed is the reason for a event occuring when the run controller
+	// faces an intermittent error during cleanup phase.
+	EventReasonCleaningFailed = "CleaningFailed"
+
 	// EventReasonLoadPipelineRunsConfigFailed is the reason for an event occuring when the
 	// loading of the pipeline runs configuration fails.
 	EventReasonLoadPipelineRunsConfigFailed = "LoadPipelineRunsConfigFailed"

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -505,11 +505,9 @@ func (mr *MockPipelineRunMockRecorder) UpdateContainer(arg0 interface{}) *gomock
 }
 
 // UpdateMessage mocks base method
-func (m *MockPipelineRun) UpdateMessage(arg0 string) error {
+func (m *MockPipelineRun) UpdateMessage(arg0 string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMessage", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateMessage", arg0)
 }
 
 // UpdateMessage indicates an expected call of UpdateMessage

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -35,9 +35,10 @@ import (
 	externalversions0 "github.com/SAP/stewardci-core/pkg/tektonclient/informers/externalversions"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	dynamic "k8s.io/client-go/dynamic"
-	v10 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v11 "k8s.io/client-go/kubernetes/typed/networking/v1"
+	v11 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v12 "k8s.io/client-go/kubernetes/typed/networking/v1"
 	v1beta10 "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
 	reflect "reflect"
 )
@@ -66,10 +67,10 @@ func (m *MockClientFactory) EXPECT() *MockClientFactoryMockRecorder {
 }
 
 // CoreV1 mocks base method
-func (m *MockClientFactory) CoreV1() v10.CoreV1Interface {
+func (m *MockClientFactory) CoreV1() v11.CoreV1Interface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CoreV1")
-	ret0, _ := ret[0].(v10.CoreV1Interface)
+	ret0, _ := ret[0].(v11.CoreV1Interface)
 	return ret0
 }
 
@@ -94,10 +95,10 @@ func (mr *MockClientFactoryMockRecorder) Dynamic() *gomock.Call {
 }
 
 // NetworkingV1 mocks base method
-func (m *MockClientFactory) NetworkingV1() v11.NetworkingV1Interface {
+func (m *MockClientFactory) NetworkingV1() v12.NetworkingV1Interface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkingV1")
-	ret0, _ := ret[0].(v11.NetworkingV1Interface)
+	ret0, _ := ret[0].(v12.NetworkingV1Interface)
 	return ret0
 }
 
@@ -539,17 +540,17 @@ func (mr *MockPipelineRunMockRecorder) UpdateRunNamespace(arg0 interface{}) *gom
 }
 
 // UpdateState mocks base method
-func (m *MockPipelineRun) UpdateState(arg0 v1alpha1.State) error {
+func (m *MockPipelineRun) UpdateState(arg0 v1alpha1.State, arg1 v10.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateState", arg0)
+	ret := m.ctrl.Call(m, "UpdateState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateState indicates an expected call of UpdateState
-func (mr *MockPipelineRunMockRecorder) UpdateState(arg0 interface{}) *gomock.Call {
+func (mr *MockPipelineRunMockRecorder) UpdateState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateState", reflect.TypeOf((*MockPipelineRun)(nil).UpdateState), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateState", reflect.TypeOf((*MockPipelineRun)(nil).UpdateState), arg0, arg1)
 }
 
 // MockPipelineRunFetcher is a mock of PipelineRunFetcher interface

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -521,11 +521,9 @@ func (mr *MockPipelineRunMockRecorder) UpdateMessage(arg0 interface{}) *gomock.C
 }
 
 // UpdateResult mocks base method
-func (m *MockPipelineRun) UpdateResult(arg0 v1alpha1.Result) error {
+func (m *MockPipelineRun) UpdateResult(arg0 v1alpha1.Result) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateResult", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateResult", arg0)
 }
 
 // UpdateResult indicates an expected call of UpdateResult

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -529,11 +529,9 @@ func (mr *MockPipelineRunMockRecorder) UpdateResult(arg0 interface{}) *gomock.Ca
 }
 
 // UpdateRunNamespace mocks base method
-func (m *MockPipelineRun) UpdateRunNamespace(arg0 string) error {
+func (m *MockPipelineRun) UpdateRunNamespace(arg0 string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRunNamespace", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateRunNamespace", arg0)
 }
 
 // UpdateRunNamespace indicates an expected call of UpdateRunNamespace

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -267,11 +267,12 @@ func (mr *MockPipelineRunMockRecorder) AddFinalizer() *gomock.Call {
 }
 
 // CommitStatus mocks base method
-func (m *MockPipelineRun) CommitStatus() error {
+func (m *MockPipelineRun) CommitStatus() ([]*v1alpha1.StateItem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitStatus")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]*v1alpha1.StateItem)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CommitStatus indicates an expected call of CommitStatus
@@ -548,12 +549,11 @@ func (mr *MockPipelineRunMockRecorder) UpdateRunNamespace(arg0 interface{}) *gom
 }
 
 // UpdateState mocks base method
-func (m *MockPipelineRun) UpdateState(arg0 v1alpha1.State) (*v1alpha1.StateItem, error) {
+func (m *MockPipelineRun) UpdateState(arg0 v1alpha1.State) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateState", arg0)
-	ret0, _ := ret[0].(*v1alpha1.StateItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // UpdateState indicates an expected call of UpdateState

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -493,11 +493,9 @@ func (mr *MockPipelineRunMockRecorder) UpdateAuxNamespace(arg0 interface{}) *gom
 }
 
 // UpdateContainer mocks base method
-func (m *MockPipelineRun) UpdateContainer(arg0 *v1.ContainerState) error {
+func (m *MockPipelineRun) UpdateContainer(arg0 *v1.ContainerState) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateContainer", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateContainer", arg0)
 }
 
 // UpdateContainer indicates an expected call of UpdateContainer

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -479,11 +479,9 @@ func (mr *MockPipelineRunMockRecorder) String() *gomock.Call {
 }
 
 // UpdateAuxNamespace mocks base method
-func (m *MockPipelineRun) UpdateAuxNamespace(arg0 string) error {
+func (m *MockPipelineRun) UpdateAuxNamespace(arg0 string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAuxNamespace", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateAuxNamespace", arg0)
 }
 
 // UpdateAuxNamespace indicates an expected call of UpdateAuxNamespace

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -331,7 +331,7 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 // and remembered so that it can be re-applied later in case of a re-try. The change function
 // must only apply changes to pipelinerun.Status.
 //
-func (r *pipelineRun) changeStatusAndStoreForRetry(change func(*api.PipelineStatus) (commitRecorderFunc, error)) error {
+func (r *pipelineRun) changeStatusAndStoreForRetry(change changeFunc) error {
 	commitRecorder, err := change(r.GetStatus())
 	if err == nil {
 		r.changes = append(r.changes, change)

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -169,7 +169,6 @@ func (r *pipelineRun) InitState() error {
 // UpdateState set end time of current (defined) state (A) and store it to the history.
 // if no current state is defined a new state (A) with cretiontime of the pipelinerun as start time is created.
 // It also creates a new current state (B) with start time.
-// Returns the state details of state A
 func (r *pipelineRun) UpdateState(state api.State) error {
 	if r.apiObj.Status.State == api.StateUndefined {
 		if err := r.InitState(); err != nil {

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -216,12 +216,12 @@ func (r *pipelineRun) UpdateResult(result api.Result) {
 	r.ensureCopy()
 	// the call below returns the error from the function. This error is always nil. Hence there
 	// is no need to return that always-nil-error.
-	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	panicOnError(r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Result = result
 		now := metav1.Now()
 		s.FinishedAt = &now
 		return nil, nil
-	})
+	}))
 }
 
 // UpdateContainer ...
@@ -230,10 +230,10 @@ func (r *pipelineRun) UpdateContainer(c *corev1.ContainerState) {
 		return
 	}
 	r.ensureCopy()
-	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	panicOnError(r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Container = *c
 		return nil, nil
-	})
+	}))
 }
 
 // StoreErrorAsMessage stores the error as message in the status
@@ -250,7 +250,7 @@ func (r *pipelineRun) StoreErrorAsMessage(err error, message string) error {
 func (r *pipelineRun) UpdateMessage(message string) {
 	r.ensureCopy()
 
-	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	panicOnError(r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		old := s.Message
 		if old != "" {
 			his := s.History
@@ -260,26 +260,26 @@ func (r *pipelineRun) UpdateMessage(message string) {
 		s.Message = utils.Trim(message)
 		s.MessageShort = utils.ShortenMessage(message, 100)
 		return nil, nil
-	})
+	}))
 }
 
 // UpdateRunNamespace overrides the namespace in which the builds happens
 func (r *pipelineRun) UpdateRunNamespace(ns string) {
 	r.ensureCopy()
-	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	panicOnError(r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Namespace = ns
 		return nil, nil
-	})
+	}))
 }
 
 // UpdateAuxNamespace overrides the namespace hosting auxiliary services
 // for the pipeline run.
 func (r *pipelineRun) UpdateAuxNamespace(ns string) {
 	r.ensureCopy()
-	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	panicOnError(r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.AuxiliaryNamespace = ns
 		return nil, nil
-	})
+	}))
 }
 
 //HasDeletionTimestamp returns true if deletion timestamp is set
@@ -422,5 +422,14 @@ func (r *pipelineRun) ensureCopy() {
 	if !r.copied {
 		r.apiObj = r.apiObj.DeepCopy()
 		r.copied = true
+	}
+}
+
+// panicOnError is intended for cases where we have to deal with an error but an error is technically not possible.
+// In such cases it is better to panic rather then just to swallow since we do not get the awareness in case of an
+// unexpected behaviour of the coding when we just swallow.
+func panicOnError(err error) {
+	if err != nil {
+		panic(err)
 	}
 }

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -36,7 +36,7 @@ type PipelineRun interface {
 	InitState() error
 	UpdateState(api.State) error
 	UpdateResult(api.Result)
-	UpdateContainer(*corev1.ContainerState) error
+	UpdateContainer(*corev1.ContainerState)
 	StoreErrorAsMessage(error, string) error
 	UpdateRunNamespace(string) error
 	UpdateAuxNamespace(string) error
@@ -225,12 +225,12 @@ func (r *pipelineRun) UpdateResult(result api.Result) {
 }
 
 // UpdateContainer ...
-func (r *pipelineRun) UpdateContainer(c *corev1.ContainerState) error {
+func (r *pipelineRun) UpdateContainer(c *corev1.ContainerState) {
 	if c == nil {
-		return nil
+		return
 	}
 	r.ensureCopy()
-	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Container = *c
 		return nil, nil
 	})

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -399,9 +399,8 @@ func (r *pipelineRun) CommitStatus() ([]*api.StateItem, error) {
 				commitRecorder, changeError = change(r.GetStatus())
 				if changeError != nil {
 					return nil
-				} else {
-					r.commitRecorders = append(r.commitRecorders, commitRecorder)
 				}
+				r.commitRecorders = append(r.commitRecorders, commitRecorder)
 			}
 		} else {
 			defer func() { isRetry = true }()

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -40,7 +40,7 @@ type PipelineRun interface {
 	StoreErrorAsMessage(error, string) error
 	UpdateRunNamespace(string) error
 	UpdateAuxNamespace(string) error
-	UpdateMessage(string) error
+	UpdateMessage(string)
 }
 
 type pipelineRun struct {
@@ -241,16 +241,16 @@ func (r *pipelineRun) StoreErrorAsMessage(err error, message string) error {
 	if err != nil {
 		text := fmt.Sprintf("ERROR: %s [%s]: %s", utils.Trim(message), r.String(), err.Error())
 		klog.V(3).Infof(text)
-		return r.UpdateMessage(text)
+		r.UpdateMessage(text)
 	}
 	return nil
 }
 
 // UpdateMessage stores string as message in the status
-func (r *pipelineRun) UpdateMessage(message string) error {
+func (r *pipelineRun) UpdateMessage(message string) {
 	r.ensureCopy()
 
-	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		old := s.Message
 		if old != "" {
 			his := s.History

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -35,7 +35,7 @@ type PipelineRun interface {
 	DeleteFinalizerIfExists() error
 	InitState() error
 	UpdateState(api.State) error
-	UpdateResult(api.Result) error
+	UpdateResult(api.Result)
 	UpdateContainer(*corev1.ContainerState) error
 	StoreErrorAsMessage(error, string) error
 	UpdateRunNamespace(string) error
@@ -212,9 +212,11 @@ func (r *pipelineRun) String() string {
 }
 
 // UpdateResult of the pipeline run
-func (r *pipelineRun) UpdateResult(result api.Result) error {
+func (r *pipelineRun) UpdateResult(result api.Result) {
 	r.ensureCopy()
-	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	// the call below returns the error from the function. This error is always nil. Hence there
+	// is no need to return that always-nil-error.
+	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Result = result
 		now := metav1.Now()
 		s.FinishedAt = &now

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -299,9 +299,6 @@ func (r *pipelineRun) HasDeletionTimestamp() bool {
 
 // AddFinalizer adds a finalizer to pipeline run
 func (r *pipelineRun) AddFinalizer() error {
-	if len(r.changes) > 0 {
-		return fmt.Errorf("cannot add finalizers when we have uncommited status updates")
-	}
 	changed, finalizerList := utils.AddStringIfMissing(r.apiObj.ObjectMeta.Finalizers, FinalizerName)
 	if changed {
 		err := r.updateFinalizers(finalizerList)
@@ -312,9 +309,6 @@ func (r *pipelineRun) AddFinalizer() error {
 
 // DeleteFinalizerIfExists deletes a finalizer from pipeline run
 func (r *pipelineRun) DeleteFinalizerIfExists() error {
-	if len(r.changes) > 0 {
-		return fmt.Errorf("cannot remove finalizers when we have uncommited status updates")
-	}
 	changed, finalizerList := utils.RemoveString(r.apiObj.ObjectMeta.Finalizers, FinalizerName)
 	if changed {
 		return r.updateFinalizers(finalizerList)
@@ -323,6 +317,9 @@ func (r *pipelineRun) DeleteFinalizerIfExists() error {
 }
 
 func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
+	if len(r.changes) > 0 {
+		return fmt.Errorf("cannot add finalizers when we have uncommited status updates")
+	}
 	if r.client == nil {
 		panic(fmt.Errorf("No factory provided to store updates [%s]", r.String()))
 	}

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -49,8 +49,10 @@ type pipelineRun struct {
 	apiObj         *api.PipelineRun
 	copied         bool
 	changes        []func(*api.PipelineStatus) (func() *api.StateItem, error)
-	commitRecorder []func() *api.StateItem
+	commitRecorder []commitRecorderFunc
 }
+
+type commitRecorderFunc func() *api.StateItem
 
 // NewPipelineRun creates a managed pipeline run object.
 // If a factory is provided a new version of the pipelinerun is fetched.
@@ -80,7 +82,7 @@ func NewPipelineRun(apiObj *api.PipelineRun, factory ClientFactory) (PipelineRun
 		copied:         true,
 		client:         client,
 		changes:        []func(*v1alpha1.PipelineStatus) (func() *api.StateItem, error){},
-		commitRecorder: []func() *api.StateItem{},
+		commitRecorder: []commitRecorderFunc{},
 	}, nil
 }
 
@@ -389,7 +391,7 @@ func (r *pipelineRun) CommitStatus() ([]*api.StateItem, error) {
 			}
 			r.apiObj = new
 			r.copied = true
-			r.commitRecorder = []func() *api.StateItem{}
+			r.commitRecorder = []commitRecorderFunc{}
 			var commitRecorder func() *api.StateItem
 			for _, change := range r.changes {
 				commitRecorder, changeError = change(r.GetStatus())

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -38,7 +38,7 @@ type PipelineRun interface {
 	UpdateResult(api.Result)
 	UpdateContainer(*corev1.ContainerState)
 	StoreErrorAsMessage(error, string) error
-	UpdateRunNamespace(string) error
+	UpdateRunNamespace(string)
 	UpdateAuxNamespace(string) error
 	UpdateMessage(string)
 }
@@ -264,9 +264,9 @@ func (r *pipelineRun) UpdateMessage(message string) {
 }
 
 // UpdateRunNamespace overrides the namespace in which the builds happens
-func (r *pipelineRun) UpdateRunNamespace(ns string) error {
+func (r *pipelineRun) UpdateRunNamespace(ns string) {
 	r.ensureCopy()
-	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Namespace = ns
 		return nil, nil
 	})

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -39,7 +39,7 @@ type PipelineRun interface {
 	UpdateContainer(*corev1.ContainerState)
 	StoreErrorAsMessage(error, string) error
 	UpdateRunNamespace(string)
-	UpdateAuxNamespace(string) error
+	UpdateAuxNamespace(string)
 	UpdateMessage(string)
 }
 
@@ -274,9 +274,9 @@ func (r *pipelineRun) UpdateRunNamespace(ns string) {
 
 // UpdateAuxNamespace overrides the namespace hosting auxiliary services
 // for the pipeline run.
-func (r *pipelineRun) UpdateAuxNamespace(ns string) error {
+func (r *pipelineRun) UpdateAuxNamespace(ns string) {
 	r.ensureCopy()
-	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.AuxiliaryNamespace = ns
 		return nil, nil
 	})

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -213,8 +213,6 @@ func (r *pipelineRun) String() string {
 // UpdateResult of the pipeline run
 func (r *pipelineRun) UpdateResult(result api.Result, ts metav1.Time) {
 	r.ensureCopy()
-	// the call below returns the error from the function. This error is always nil. Hence there
-	// is no need to return that always-nil-error.
 	r.mustChangeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Result = result
 		s.FinishedAt = &ts

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/client/clientset/versioned/typed/steward/v1alpha1"
 	utils "github.com/SAP/stewardci-core/pkg/utils"
@@ -48,7 +47,7 @@ type pipelineRun struct {
 	client         stewardv1alpha1.PipelineRunInterface
 	apiObj         *api.PipelineRun
 	copied         bool
-	changes        []func(*api.PipelineStatus) (commitRecorderFunc, error)
+	changes        []changeFunc
 	commitRecorder []commitRecorderFunc
 }
 
@@ -82,7 +81,7 @@ func NewPipelineRun(apiObj *api.PipelineRun, factory ClientFactory) (PipelineRun
 		apiObj:         obj,
 		copied:         true,
 		client:         client,
-		changes:        []func(*v1alpha1.PipelineStatus) (commitRecorderFunc, error){},
+		changes:        []changeFunc{},
 		commitRecorder: []commitRecorderFunc{},
 	}, nil
 }
@@ -413,7 +412,7 @@ func (r *pipelineRun) CommitStatus() ([]*api.StateItem, error) {
 		}
 		return err
 	})
-	r.changes = []func(*api.PipelineStatus) (commitRecorderFunc, error){}
+	r.changes = []changeFunc{}
 	if changeError != nil {
 		return nil, changeError
 	}

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -149,7 +149,7 @@ func (r *pipelineRun) GetSpec() *api.PipelineSpec {
 func (r *pipelineRun) InitState() error {
 	r.ensureCopy()
 	klog.V(3).Infof("Init State [%s]", r.String())
-	err := r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 
 		if s.State != api.StateUndefined {
 			return nil, fmt.Errorf("Cannot initialize multiple times")
@@ -163,9 +163,6 @@ func (r *pipelineRun) InitState() error {
 		s.State = api.StateNew
 		return nil, nil
 	})
-
-	return err
-
 }
 
 // UpdateState set end time of current (defined) state (A) and store it to the history.

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -329,7 +329,7 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 }
 
 // mustChangeStatusAndStoreForRetry calls changeStatusAndStoreForRetry and
-// oanics in case of an error.
+// panics in case of an error.
 func (r *pipelineRun) mustChangeStatusAndStoreForRetry(change changeFunc) {
 	err := r.changeStatusAndStoreForRetry((change))
 	if err != nil {

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -335,7 +335,7 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 
 // changeStatusAndStoreForRetry receives a function applying changes to pipelinerun.Status
 // This function get executed on the current memory representation of the pipeline run
-// and remembered so that it can be re-applied later in case of a re-tr. The change function
+// and remembered so that it can be re-applied later in case of a re-try. The change function
 // must only apply changes to pipelinerun.Status.
 //
 func (r *pipelineRun) changeStatusAndStoreForRetry(change func(*api.PipelineStatus) (func() *api.StateItem, error)) error {

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -339,10 +339,10 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 // must only apply changes to pipelinerun.Status.
 //
 func (r *pipelineRun) changeStatusAndStoreForRetry(change func(*api.PipelineStatus) (func() *api.StateItem, error)) error {
-	commitRecoder, err := change(r.GetStatus())
+	commitRecorder, err := change(r.GetStatus())
 	if err == nil {
 		r.changes = append(r.changes, change)
-		r.commitRecorder = append(r.commitRecorder, commitRecoder)
+		r.commitRecorder = append(r.commitRecorder, commitRecorder)
 	}
 
 	return err

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -214,13 +214,12 @@ func (r *pipelineRun) String() string {
 // UpdateResult of the pipeline run
 func (r *pipelineRun) UpdateResult(result api.Result) error {
 	r.ensureCopy()
-	err := r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Result = result
 		now := metav1.Now()
 		s.FinishedAt = &now
 		return nil, nil
 	})
-	return err
 }
 
 // UpdateContainer ...
@@ -229,12 +228,10 @@ func (r *pipelineRun) UpdateContainer(c *corev1.ContainerState) error {
 		return nil
 	}
 	r.ensureCopy()
-	err := r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Container = *c
 		return nil, nil
 	})
-
-	return err
 }
 
 // StoreErrorAsMessage stores the error as message in the status
@@ -251,7 +248,7 @@ func (r *pipelineRun) StoreErrorAsMessage(err error, message string) error {
 func (r *pipelineRun) UpdateMessage(message string) error {
 	r.ensureCopy()
 
-	err := r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		old := s.Message
 		if old != "" {
 			his := s.History
@@ -262,18 +259,15 @@ func (r *pipelineRun) UpdateMessage(message string) error {
 		s.MessageShort = utils.ShortenMessage(message, 100)
 		return nil, nil
 	})
-
-	return err
 }
 
 // UpdateRunNamespace overrides the namespace in which the builds happens
 func (r *pipelineRun) UpdateRunNamespace(ns string) error {
 	r.ensureCopy()
-	err := r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
+	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Namespace = ns
 		return nil, nil
 	})
-	return err
 }
 
 // UpdateAuxNamespace overrides the namespace hosting auxiliary services

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -52,6 +52,7 @@ type pipelineRun struct {
 	commitRecorder []commitRecorderFunc
 }
 
+type changeFunc func(*api.PipelineStatus) (commitRecorderFunc, error)
 type commitRecorderFunc func() *api.StateItem
 
 // NewPipelineRun creates a managed pipeline run object.

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -552,7 +552,7 @@ func Test_pipelineRun_changeStatusAndUpdateSafely_SetsUpdateResult_IfNoConflict(
 	}
 
 	changeCallCount := 0
-	changeFunc := func(*api.PipelineStatus) (func() *api.StateItem, error) {
+	changeFunc := func(*api.PipelineStatus) (commitRecorderFunc, error) {
 		changeCallCount++
 		return nil, nil
 	}
@@ -584,7 +584,7 @@ func Test_pipelineRun_changeStatusAndUpdateSafely_NoUpdateOnChangeErrorInFirstAt
 
 	changeError := fmt.Errorf("ChangeError1")
 	changeCallCount := 0
-	changeFunc := func(*api.PipelineStatus) (func() *api.StateItem, error) {
+	changeFunc := func(*api.PipelineStatus) (commitRecorderFunc, error) {
 		changeCallCount++
 		return nil, changeError
 	}
@@ -630,7 +630,7 @@ func Test_pipelineRun_changeStatusAndUpdateSafely_SetsUpdateResult_IfConflict(t 
 	}
 
 	changeCallCount := 0
-	changeFunc := func(*api.PipelineStatus) (func() *api.StateItem, error) {
+	changeFunc := func(*api.PipelineStatus) (commitRecorderFunc, error) {
 		changeCallCount++
 		return nil, nil
 	}
@@ -675,7 +675,7 @@ func Test_pipelineRun_changeStatusAndUpdateSafely_FailsAfterTooManyConflicts(t *
 	}
 
 	changeCallCount := 0
-	changeFunc := func(*api.PipelineStatus) (func() *api.StateItem, error) {
+	changeFunc := func(*api.PipelineStatus) (commitRecorderFunc, error) {
 		changeCallCount++
 		return nil, nil
 	}
@@ -721,7 +721,7 @@ func Test_pipelineRun_changeStatusAndUpdateSafely_ReturnsErrorIfFetchFailed(t *t
 	}
 
 	changeCallCount := 0
-	changeFunc := func(*api.PipelineStatus) (func() *api.StateItem, error) {
+	changeFunc := func(*api.PipelineStatus) (commitRecorderFunc, error) {
 		changeCallCount++
 		return nil, nil
 	}
@@ -746,7 +746,7 @@ func Test_pipelineRun_CommitStatus_PanicsIfNoClientFactory(t *testing.T) {
 	examinee, err := NewPipelineRun(run, nil /* client factory */)
 	assert.NilError(t, err)
 	examinee2 := examinee.(*pipelineRun)
-	examinee2.changeStatusAndStoreForRetry(func(*api.PipelineStatus) (func() *api.StateItem, error) { /* foo */ return nil, nil })
+	examinee2.changeStatusAndStoreForRetry(func(*api.PipelineStatus) (commitRecorderFunc, error) { /* foo */ return nil, nil })
 
 	// EXERCISE and VERIFY
 	assert.Assert(t, cmp.Panics(

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -254,7 +254,7 @@ func Test_pipelineRun_InitState_ReturnsErrorIfCalledMultipleTimes(t *testing.T) 
 			resultErr := examinee.InitState()
 			assert.NilError(t, resultErr)
 
-			resultErr = examinee.UpdateState(oldState)
+			resultErr = examinee.UpdateState(oldState, metav1.Now())
 			assert.NilError(t, resultErr)
 
 			// EXERCISE
@@ -277,7 +277,7 @@ func Test_pipelineRun_UpdateState_HasAutomaticInitialization(t *testing.T) {
 	assert.NilError(t, err)
 
 	// EXERCISE
-	resultErr := examinee.UpdateState(api.StatePreparing)
+	resultErr := examinee.UpdateState(api.StatePreparing, metav1.Now())
 	assert.NilError(t, resultErr)
 	results, resultErr := examinee.CommitStatus()
 
@@ -308,7 +308,7 @@ func Test_pipelineRun_UpdateState_AfterFirstCall(t *testing.T) {
 	assert.NilError(t, err)
 
 	// EXERCISE
-	resultErr := examinee.UpdateState(api.StatePreparing)
+	resultErr := examinee.UpdateState(api.StatePreparing, metav1.Now())
 	assert.NilError(t, resultErr)
 	results, resultErr := examinee.CommitStatus()
 
@@ -338,12 +338,12 @@ func Test_pipelineRun_UpdateState_AfterSecondCall(t *testing.T) {
 	assert.NilError(t, err)
 	err = examinee.InitState()
 	assert.NilError(t, err)
-	err = examinee.UpdateState(api.StatePreparing) // first call
+	err = examinee.UpdateState(api.StatePreparing, metav1.Now()) // first call
 	assert.NilError(t, err)
 	factory.Sleep("let time elapse to check timestamps afterwards")
 
 	// EXERCISE
-	resultErr := examinee.UpdateState(api.StateRunning) // second call
+	resultErr := examinee.UpdateState(api.StateRunning, metav1.Now()) // second call
 	assert.NilError(t, resultErr)
 	results, resultErr := examinee.CommitStatus()
 
@@ -378,12 +378,12 @@ func Test_pipelineRun_UpdateStateToFinished_HistoryIfUpdateStateCalledBefore(t *
 	assert.NilError(t, err)
 	err = examinee.InitState()
 	assert.NilError(t, err)
-	err = examinee.UpdateState(api.StatePreparing) // called before
+	err = examinee.UpdateState(api.StatePreparing, metav1.Now()) // called before
 	assert.NilError(t, err)
 	factory.Sleep("let time elapse to check timestamps afterwards")
 
 	// EXERCISE
-	examinee.UpdateState(api.StateFinished)
+	examinee.UpdateState(api.StateFinished, metav1.Now())
 	_, err = examinee.CommitStatus()
 	assert.NilError(t, err)
 
@@ -488,7 +488,7 @@ func Test_pipelineRun_UpdateState_PropagatesError(t *testing.T) {
 	factory.StewardClientset().PrependReactor("update", "*", fake.NewErrorReactor(expectedError))
 
 	// EXCERCISE
-	examinee.UpdateState(api.StateWaiting)
+	examinee.UpdateState(api.StateWaiting, metav1.Now())
 	_, err = examinee.CommitStatus()
 
 	// VERIFY
@@ -518,7 +518,7 @@ func Test_pipelineRun_CommitStatus_RetriesOnConflict(t *testing.T) {
 	assert.NilError(t, err)
 	err = examinee.InitState()
 	assert.NilError(t, err)
-	resultErr := examinee.UpdateState(api.StateWaiting)
+	resultErr := examinee.UpdateState(api.StateWaiting, metav1.Now())
 	assert.NilError(t, resultErr)
 
 	// EXCERCISE

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -267,7 +267,7 @@ func Test_pipelineRun_InitState_ReturnsErrorIfCalledMultipleTimes(t *testing.T) 
 	}
 }
 
-func Test_pipelineRun_UpdateState_FailsWithoutInit(t *testing.T) {
+func Test_pipelineRun_UpdateState_HasAutomaticInitialization(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
@@ -277,10 +277,19 @@ func Test_pipelineRun_UpdateState_FailsWithoutInit(t *testing.T) {
 	assert.NilError(t, err)
 
 	// EXERCISE
-	_, resultErr := examinee.UpdateState(api.StatePreparing)
+	result, resultErr := examinee.UpdateState(api.StatePreparing)
 
 	// VERIFY
-	assert.Error(t, resultErr, "Cannot update uninitialize state")
+	assert.NilError(t, resultErr)
+
+	assert.Equal(t, api.StatePreparing, examinee.GetStatus().State)
+	assert.Equal(t, 1, len(examinee.GetStatus().StateHistory))
+	assert.Equal(t, api.StateNew, examinee.GetStatus().StateHistory[0].State)
+	startedAt := examinee.GetStatus().StartedAt
+	assert.Assert(t, !startedAt.IsZero())
+	assert.Equal(t, *startedAt, examinee.GetStatus().StateHistory[0].FinishedAt)
+	assert.Equal(t, api.StateNew, result.State)
+	assert.Equal(t, *startedAt, result.FinishedAt)
 }
 
 func Test_pipelineRun_UpdateState_AfterFirstCall(t *testing.T) {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -355,7 +355,10 @@ func (c *Controller) syncHandler(key string) error {
 		}
 		pipelineRun.UpdateResult(api.ResultErrorInfra)
 		pipelineRun.StoreErrorAsMessage(err, "failed to load configuration for pipeline runs")
-		runManager.Cleanup(pipelineRun)
+		err = runManager.Cleanup(pipelineRun)
+		if err != nil {
+			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonCleaningFailed, err.Error())
+		}
 		err = c.finish(pipelineRun)
 		if err == nil {
 			c.metrics.CountResult(pipelineRun.GetStatus().Result)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -437,8 +437,6 @@ func (c *Controller) changeAndCommitStateAndMeter(pipelineRun k8s.PipelineRun, s
 	return c.commitStatusAndMeter(pipelineRun)
 }
 func (c *Controller) setCleaningAndCountResult(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
-	// TODO: revisit: during state cleaning we have already the result. From the pure doctrine point of view
-	// that is questionable since only final states (finished) have a result. But ok, cleaning is close to finished ...
 	pipelineRun.UpdateResult(result, ts)
 	if errClean := c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, ts); errClean != nil {
 		return errClean

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -280,8 +280,7 @@ func (c *Controller) syncHandler(key string) error {
 		return pipelineRun.DeleteFinalizerIfExists()
 	}
 
-	// Check if object has deletion timestamp
-	// If not, try to add finalizer if missing
+	// Check if object has deletion timestamp ...
 	if pipelineRun.HasDeletionTimestamp() {
 		runManager := c.createRunManager(pipelineRun)
 		err = runManager.Cleanup(pipelineRun)
@@ -291,6 +290,7 @@ func (c *Controller) syncHandler(key string) error {
 		}
 		return c.updateStateAndResult(pipelineRun, api.StateFinished, api.ResultDeleted, metav1.Now())
 	}
+	// ... if not, try to add finalizer if missing
 	pipelineRun.AddFinalizer()
 
 	// Check if pipeline run is aborted

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -287,10 +287,7 @@ func (c *Controller) syncHandler(key string) error {
 		runManager := c.createRunManager(pipelineRun)
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			err = pipelineRun.UpdateResult(api.ResultDeleted)
-			if err != nil {
-				return err
-			}
+			pipelineRun.UpdateResult(api.ResultDeleted)
 			err = c.finish(pipelineRun)
 			if err == nil {
 				c.metrics.CountResult(api.ResultDeleted)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -383,10 +383,10 @@ func (c *Controller) syncHandler(key string) error {
 		if finished, result := run.IsFinished(); finished {
 			pipelineRun.UpdateMessage(run.GetMessage())
 			return c.updateStateAndResult(pipelineRun, api.StateCleaning, result, *run.GetCompletionTime())
-		} else {
-			// commit container update
-			c.commitStatusAndMeter(pipelineRun)
 		}
+		// commit container update
+		c.commitStatusAndMeter(pipelineRun)
+
 	case api.StateCleaning:
 		err = runManager.Cleanup(pipelineRun)
 		if err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -285,8 +285,7 @@ func (c *Controller) syncHandler(key string) error {
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
 			now := metav1.Now()
-			pipelineRun.UpdateResult(api.ResultDeleted, now)
-			err = c.finish(pipelineRun, now)
+			err = c.updateResultAndFinish(pipelineRun, api.ResultDeleted, now)
 			if err == nil {
 				c.metrics.CountResult(api.ResultDeleted)
 			}
@@ -356,8 +355,7 @@ func (c *Controller) syncHandler(key string) error {
 			}
 			pipelineRun.StoreErrorAsMessage(err, "failed to load configuration for pipeline runs")
 			now := metav1.Now()
-			pipelineRun.UpdateResult(api.ResultErrorInfra, now)
-			err = c.finish(pipelineRun, now)
+			err = c.updateResultAndFinish(pipelineRun, api.ResultErrorInfra, now)
 			if err == nil {
 				c.metrics.CountResult(pipelineRun.GetStatus().Result)
 			}
@@ -461,6 +459,11 @@ func (c *Controller) commitStatusAndMeter(pipelineRun k8s.PipelineRun) error {
 		}
 	}
 	return nil
+}
+
+func (c *Controller) updateResultAndFinish(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
+	pipelineRun.UpdateResult(result, ts)
+	return c.finish(pipelineRun, ts)
 }
 
 func (c *Controller) finish(pipelineRun k8s.PipelineRun, ts metav1.Time) error {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -462,10 +462,7 @@ func (c *Controller) commitStatusAndMeter(pipelineRun k8s.PipelineRun) error {
 }
 
 func (c *Controller) finish(pipelineRun k8s.PipelineRun, ts metav1.Time) error {
-	if err := c.changeState(pipelineRun, api.StateFinished, ts); err != nil {
-		return err
-	}
-	if err := c.commitStatusAndMeter(pipelineRun); err != nil {
+	if err := c.changeAndCommitStateAndMeter(pipelineRun, api.StateFinished, ts); err != nil {
 		return err
 	}
 	return pipelineRun.DeleteFinalizerIfExists()

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -206,7 +206,7 @@ func (c *Controller) processNextWorkItem() bool {
 }
 
 func (c *Controller) changeState(pipelineRun k8s.PipelineRun, state api.State) error {
-	err := pipelineRun.UpdateState(state)
+	err := pipelineRun.UpdateState(state, metav1.Now())
 	if err != nil {
 		klog.V(3).Infof("Failed to UpdateState of [%s] to %q: %q", pipelineRun.String(), state, err.Error())
 		return err

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -285,15 +285,11 @@ func (c *Controller) syncHandler(key string) error {
 	if pipelineRun.HasDeletionTimestamp() {
 		runManager := c.createRunManager(pipelineRun)
 		err = runManager.Cleanup(pipelineRun)
-		if err == nil {
-			err = c.updateStateAndResult(pipelineRun, api.StateFinished, api.ResultDeleted, metav1.Now())
-			if err == nil {
-				c.metrics.CountResult(api.ResultDeleted)
-			}
-		} else {
+		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonCleaningFailed, err.Error())
+			return err
 		}
-		return err
+		return c.updateStateAndResult(pipelineRun, api.StateFinished, api.ResultDeleted, metav1.Now())
 	}
 	pipelineRun.AddFinalizer()
 

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -370,7 +370,7 @@ func (c *Controller) syncHandler(key string) error {
 	case api.StatePreparing:
 		// TODO namespaces contains the namespace at 0 and auxNamespace at 1. Should be improved,
 		// only temporary ... Let's see if it works and improve if so ...
-		namespaces, err := runManager.Start(pipelineRun, pipelineRunsConfig)
+		namespace, auxNamespace, err := runManager.Start(pipelineRun, pipelineRunsConfig)
 		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonPreparingFailed, err.Error())
 			resultClass := serrors.GetClass(err)
@@ -390,12 +390,10 @@ func (c *Controller) syncHandler(key string) error {
 			}
 			return err
 		}
-		if len(namespaces) >= 1 && len(namespaces[0]) > 0 {
-			pipelineRun.UpdateRunNamespace(namespaces[0])
-		}
-		if len(namespaces) > 1 && len(namespaces[1]) > 0 {
-			pipelineRun.UpdateAuxNamespace(namespaces[1])
-		}
+
+		pipelineRun.UpdateRunNamespace(namespace)
+		pipelineRun.UpdateAuxNamespace(auxNamespace)
+
 		if err = c.changeState(pipelineRun, api.StateWaiting); err != nil {
 			return err
 		}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -34,7 +34,7 @@ const kind = "PipelineRuns"
 
 // Used for logging (control loop) "still alive" messages
 var heartbeatIntervalSeconds int64 = 60
-var heartbeatTimer int64 = 0
+var heartbeatTimer int64
 
 // Interval for histogram creation set to prometheus default scrape interval
 var meteringInterval = time.Minute * 1

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -368,8 +368,6 @@ func (c *Controller) syncHandler(key string) error {
 	// Process pipeline run based on current state
 	switch state := pipelineRun.GetStatus().State; state {
 	case api.StatePreparing:
-		// TODO namespaces contains the namespace at 0 and auxNamespace at 1. Should be improved,
-		// only temporary ... Let's see if it works and improve if so ...
 		namespace, auxNamespace, err := runManager.Start(pipelineRun, pipelineRunsConfig)
 		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonPreparingFailed, err.Error())

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -295,6 +295,8 @@ func (c *Controller) syncHandler(key string) error {
 			if err == nil {
 				c.metrics.CountResult(api.ResultDeleted)
 			}
+		} else {
+			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonCleaningFailed, err.Error())
 		}
 		return err
 	}
@@ -450,6 +452,9 @@ func (c *Controller) syncHandler(key string) error {
 		}
 	case api.StateCleaning:
 		err = runManager.Cleanup(pipelineRun)
+		if err != nil {
+			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonCleaningFailed, err.Error())
+		}
 		return c.finish(pipelineRun)
 	default:
 		klog.V(2).Infof("Skip PipelineRun with state %s", pipelineRun.GetStatus().State)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -368,7 +368,7 @@ func (c *Controller) syncHandler(key string) error {
 	// Process pipeline run based on current state
 	switch state := pipelineRun.GetStatus().State; state {
 	case api.StatePreparing:
-		err = runManager.Start(pipelineRun, pipelineRunsConfig)
+		_, err := runManager.Start(pipelineRun, pipelineRunsConfig)
 		if err != nil {
 			c.recorder.Event(pipelineRunAPIObj, corev1.EventTypeWarning, api.EventReasonPreparingFailed, err.Error())
 			resultClass := serrors.GetClass(err)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -284,8 +284,7 @@ func (c *Controller) syncHandler(key string) error {
 		}
 		err = runManager.Cleanup(pipelineRun)
 		if err == nil {
-			now := metav1.Now()
-			err = c.updateResultAndFinish(pipelineRun, api.ResultDeleted, now)
+			err = c.updateResultAndFinish(pipelineRun, api.ResultDeleted)
 			if err == nil {
 				c.metrics.CountResult(api.ResultDeleted)
 			}
@@ -354,8 +353,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			pipelineRun.StoreErrorAsMessage(err, "failed to load configuration for pipeline runs")
-			now := metav1.Now()
-			err = c.updateResultAndFinish(pipelineRun, api.ResultErrorInfra, now)
+			err = c.updateResultAndFinish(pipelineRun, api.ResultErrorInfra)
 			if err == nil {
 				c.metrics.CountResult(pipelineRun.GetStatus().Result)
 			}
@@ -461,9 +459,10 @@ func (c *Controller) commitStatusAndMeter(pipelineRun k8s.PipelineRun) error {
 	return nil
 }
 
-func (c *Controller) updateResultAndFinish(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
-	pipelineRun.UpdateResult(result, ts)
-	return c.finish(pipelineRun, ts)
+func (c *Controller) updateResultAndFinish(pipelineRun k8s.PipelineRun, result api.Result) error {
+	now := metav1.Now()
+	pipelineRun.UpdateResult(result, now)
+	return c.finish(pipelineRun, now)
 }
 
 func (c *Controller) finish(pipelineRun k8s.PipelineRun, ts metav1.Time) error {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -394,7 +394,6 @@ func (c *Controller) syncHandler(key string) error {
 		if err = c.changeState(pipelineRun, api.StateWaiting); err != nil {
 			return err
 		}
-		// TODO try to get rid of that commit
 		if err := c.commitAndMeter(pipelineRun); err != nil {
 			return err
 		}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -464,7 +464,7 @@ func (c *Controller) commitStatusAndMeter(pipelineRun k8s.PipelineRun) error {
 func (c *Controller) updateResultAndFinish(pipelineRun k8s.PipelineRun, result api.Result) error {
 	now := metav1.Now()
 	pipelineRun.UpdateResult(result, now)
-	if err := c.changeAndCommitStateAndMeter(pipelineRun, api.StateFinished, ts); err != nil {
+	if err := c.changeAndCommitStateAndMeter(pipelineRun, api.StateFinished, now); err != nil {
 		return err
 	}
 	return pipelineRun.DeleteFinalizerIfExists()

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -446,10 +446,14 @@ func (c *Controller) setCleaningAndCountResult(pipelineRun k8s.PipelineRun, resu
 }
 
 func (c *Controller) commitStatusAndMeter(pipelineRun k8s.PipelineRun) error {
+	start := time.Now()
 	finishedStates, err := pipelineRun.CommitStatus()
 	if err != nil {
 		return err
 	}
+	end := time.Now()
+	elapsed := end.Sub(start)
+	c.metrics.ObserveUpdateDurationByType("UpdateState", elapsed)
 	for _, finishedState := range finishedStates {
 		err := c.metrics.ObserveDurationByState(finishedState)
 		if err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -270,14 +270,14 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// fast exit with finalizer cleanup
-	if pipelineRun.GetStatus().State == api.StateFinished {
-		return pipelineRun.DeleteFinalizerIfExists()
-	}
-
 	// If pipelineRun is not found there is nothing to sync
 	if pipelineRun == nil {
 		return nil
+	}
+
+	// fast exit with finalizer cleanup
+	if pipelineRun.GetStatus().State == api.StateFinished {
+		return pipelineRun.DeleteFinalizerIfExists()
 	}
 
 	// Check if object has deletion timestamp

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -397,11 +397,9 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				expectedError:          fmt.Errorf("pipeline execution is paused while the system is in maintenance mode"),
 			},
 			{
-				name:         "new_get_cofig_fail_not_recoverable",
-				pipelineSpec: api.PipelineSpec{},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
-				},
+				name:                  "new_get_cofig_fail_not_recoverable",
+				pipelineSpec:          api.PipelineSpec{},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
 				pipelineRunsConfigStub: func() (*cfg.PipelineRunsConfigStruct, error) {
 					return nil, error1
 				},

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -295,7 +295,7 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				name:         "new_ok",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, nil)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				isMaintenanceModeStub:  newIsMaintenanceModeStub(false, nil),
@@ -432,7 +432,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, nil)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultUndefined,
@@ -445,7 +445,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return(error1)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, error1)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultUndefined,
@@ -463,7 +463,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return(serrors.Classify(error1, api.ResultErrorContent))
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, serrors.Classify(error1, api.ResultErrorContent))
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultErrorContent,

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -295,7 +295,7 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				name:         "new_ok",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, nil)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return("", "", nil)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				isMaintenanceModeStub:  newIsMaintenanceModeStub(false, nil),
@@ -413,7 +413,6 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 	errorRecover1 := serrors.Recoverable(error1)
 
 	for _, maintenanceMode := range []bool{true, false} {
-
 		for _, test := range []struct {
 			name                   string
 			pipelineSpec           api.PipelineSpec
@@ -432,7 +431,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, nil)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return("", "", nil)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultUndefined,
@@ -445,7 +444,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, error1)
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return("", "", error1)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultUndefined,
@@ -463,7 +462,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
 
-					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return([]string{}, serrors.Classify(error1, api.ResultErrorContent))
+					rm.EXPECT().Start(gomock.Any(), gomock.Any()).Return("", "", serrors.Classify(error1, api.ResultErrorContent))
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
 				expectedResult:         api.ResultErrorContent,

--- a/pkg/runctl/run/interfaces.go
+++ b/pkg/runctl/run/interfaces.go
@@ -10,7 +10,7 @@ import (
 
 // Manager manages runs
 type Manager interface {
-	Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) error
+	Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) ([]string, error)
 	GetRun(pipelineRun k8s.PipelineRun) (Run, error)
 	Cleanup(pipelineRun k8s.PipelineRun) error
 }

--- a/pkg/runctl/run/interfaces.go
+++ b/pkg/runctl/run/interfaces.go
@@ -10,7 +10,7 @@ import (
 
 // Manager manages runs
 type Manager interface {
-	Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) ([]string, error)
+	Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (string, string, error)
 	GetRun(pipelineRun k8s.PipelineRun) (Run, error)
 	Cleanup(pipelineRun k8s.PipelineRun) error
 }

--- a/pkg/runctl/run/mocks/mocks.go
+++ b/pkg/runctl/run/mocks/mocks.go
@@ -171,12 +171,13 @@ func (mr *MockManagerMockRecorder) GetRun(arg0 interface{}) *gomock.Call {
 }
 
 // Start mocks base method
-func (m *MockManager) Start(arg0 k8s.PipelineRun, arg1 *cfg.PipelineRunsConfigStruct) ([]string, error) {
+func (m *MockManager) Start(arg0 k8s.PipelineRun, arg1 *cfg.PipelineRunsConfigStruct) (string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0, arg1)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Start indicates an expected call of Start

--- a/pkg/runctl/run/mocks/mocks.go
+++ b/pkg/runctl/run/mocks/mocks.go
@@ -171,11 +171,12 @@ func (mr *MockManagerMockRecorder) GetRun(arg0 interface{}) *gomock.Call {
 }
 
 // Start mocks base method
-func (m *MockManager) Start(arg0 k8s.PipelineRun, arg1 *cfg.PipelineRunsConfigStruct) error {
+func (m *MockManager) Start(arg0 k8s.PipelineRun, arg1 *cfg.PipelineRunsConfigStruct) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Start indicates an expected call of Start

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -94,7 +94,7 @@ func newRunManager(factory k8s.ClientFactory, secretProvider secrets.SecretProvi
 
 // Start prepares the isolated environment for a new run and starts
 // the run in this environment.
-func (c *runManager) Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) error {
+func (c *runManager) Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) ([]string, error) {
 	var err error
 	ctx := &runContext{
 		pipelineRun:        pipelineRun,
@@ -104,18 +104,18 @@ func (c *runManager) Start(pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.
 	}
 	err = c.cleanupNamespaces(ctx)
 	if err != nil {
-		return err
+		return []string{}, err
 	}
 	err = c.prepareRunNamespace(ctx)
 	if err != nil {
-		return err
+		return []string{}, err
 	}
 	err = c.createTektonTaskRun(ctx)
 	if err != nil {
-		return err
+		return []string{}, err
 	}
 
-	return nil
+	return []string{ctx.runNamespace, ctx.auxNamespace}, nil
 }
 
 // prepareRunNamespace creates a new namespace for the pipeline run

--- a/pkg/runctl/run_manager.go
+++ b/pkg/runctl/run_manager.go
@@ -694,11 +694,6 @@ func (c *runManager) cleanup(ctx *runContext) error {
 		}
 	}
 
-	if firstErr != nil {
-		// TODO Don't store on resource as message. Add it as event.
-		ctx.pipelineRun.StoreErrorAsMessage(firstErr, "cleanup failed")
-	}
-
 	return firstErr
 }
 

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -153,13 +153,6 @@ func Test__runManager_prepareRunNamespace__Calls__copySecretsToRunNamespace__And
 		return "", nil, expectedError
 	}
 
-	var cleanupCalled bool
-	examinee.testing.cleanupStub = func(ctx *runContext) error {
-		assert.Assert(t, ctx.pipelineRun == pipelineRunHelper)
-		cleanupCalled = true
-		return nil
-	}
-
 	runCtx := &runContext{
 		pipelineRun:        pipelineRunHelper,
 		pipelineRunsConfig: config,
@@ -171,7 +164,6 @@ func Test__runManager_prepareRunNamespace__Calls__copySecretsToRunNamespace__And
 	// VERIFY
 	assert.Equal(t, expectedError, resultErr)
 	assert.Assert(t, methodCalled == true)
-	assert.Assert(t, cleanupCalled == true)
 }
 
 func Test__runManager_prepareRunNamespace__Calls_setupServiceAccount_AndPropagatesError(t *testing.T) {
@@ -208,13 +200,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupServiceAccount_AndPropagat
 		return expectedPipelineCloneSecretName, expectedImagePullSecretNames, nil
 	}
 
-	var cleanupCalled bool
-	examinee.testing.cleanupStub = func(ctx *runContext) error {
-		assert.Assert(t, ctx.pipelineRun == pipelineRunHelper)
-		cleanupCalled = true
-		return nil
-	}
-
 	runCtx := &runContext{
 		pipelineRun:        pipelineRunHelper,
 		pipelineRunsConfig: config,
@@ -226,7 +211,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupServiceAccount_AndPropagat
 	// VERIFY
 	assert.Equal(t, expectedError, resultErr)
 	assert.Assert(t, methodCalled == true)
-	assert.Assert(t, cleanupCalled == true)
 }
 
 func Test__runManager_prepareRunNamespace__Calls_setupStaticNetworkPolicies_AndPropagatesError(t *testing.T) {
@@ -256,13 +240,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupStaticNetworkPolicies_AndP
 		return expectedError
 	}
 
-	var cleanupCalled bool
-	examinee.testing.cleanupStub = func(ctx *runContext) error {
-		assert.Assert(t, ctx.pipelineRun == pipelineRunHelper)
-		cleanupCalled = true
-		return nil
-	}
-
 	runCtx := &runContext{
 		pipelineRun:        pipelineRunHelper,
 		pipelineRunsConfig: config,
@@ -274,7 +251,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupStaticNetworkPolicies_AndP
 	// VERIFY
 	assert.Equal(t, expectedError, resultErr)
 	assert.Assert(t, methodCalled == true)
-	assert.Assert(t, cleanupCalled == true)
 }
 
 func Test__runManager_setupStaticNetworkPolicies__Succeeds(t *testing.T) {

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -150,7 +150,6 @@ func Test__runManager_prepareRunNamespace__Calls__copySecretsToRunNamespace__And
 		methodCalled = true
 		assert.Assert(t, ctx.pipelineRun == pipelineRunHelper)
 		assert.Assert(t, ctx.runNamespace != "")
-		assert.Equal(t, pipelineRunHelper.GetRunNamespace(), ctx.runNamespace)
 		return "", nil, expectedError
 	}
 
@@ -201,7 +200,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupServiceAccount_AndPropagat
 	examinee.testing.setupServiceAccountStub = func(ctx *runContext, pipelineCloneSecretName string, imagePullSecretNames []string) error {
 		methodCalled = true
 		assert.Assert(t, ctx.runNamespace != "")
-		assert.Equal(t, pipelineRunHelper.GetRunNamespace(), ctx.runNamespace)
 		assert.Equal(t, expectedPipelineCloneSecretName, pipelineCloneSecretName)
 		assert.DeepEqual(t, expectedImagePullSecretNames, imagePullSecretNames)
 		return expectedError
@@ -255,7 +253,6 @@ func Test__runManager_prepareRunNamespace__Calls_setupStaticNetworkPolicies_AndP
 	examinee.testing.setupStaticNetworkPoliciesStub = func(ctx *runContext) error {
 		methodCalled = true
 		assert.Assert(t, ctx.runNamespace != "")
-		assert.Equal(t, pipelineRunHelper.GetRunNamespace(), ctx.runNamespace)
 		return expectedError
 	}
 
@@ -1291,11 +1288,11 @@ func Test__runManager_Start__CreatesTektonTaskRun(t *testing.T) {
 	examinee.testing = newRunManagerTestingWithRequiredStubs()
 
 	// EXERCISE
-	_, _, resultError := examinee.Start(mockPipelineRun, config)
+	runNamespace, _, resultError := examinee.Start(mockPipelineRun, config)
 	assert.NilError(t, resultError)
 
 	// VERIFY
-	result, err := mockFactory.TektonV1beta1().TaskRuns(mockPipelineRun.GetRunNamespace()).Get(
+	result, err := mockFactory.TektonV1beta1().TaskRuns(runNamespace).Get(
 		tektonTaskRunName, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, result != nil)

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -1355,7 +1355,6 @@ func Test__runManager_Start__Perform_cleanup_on_error(t *testing.T) {
 			assert.Assert(t, cleanupCalled == test.expectedCleanupCount)
 		})
 	}
-
 }
 
 func Test__runManager_addTektonTaskRunParamsForJenkinsfileRunnerImage(t *testing.T) {

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -1492,6 +1492,8 @@ func Test__runManager_Cleanup__RemovesNamespaces(t *testing.T) {
 			}
 			err = examinee.prepareRunNamespace(runCtx)
 			assert.NilError(t, err)
+			runCtx.pipelineRun.UpdateRunNamespace(runCtx.runNamespace)
+			runCtx.pipelineRun.UpdateAuxNamespace(runCtx.auxNamespace)
 			_, err = runCtx.pipelineRun.CommitStatus()
 			assert.NilError(t, err)
 			{

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -1484,7 +1484,7 @@ func Test__runManager_Start__DoesNotSetPipelineRunStatus(t *testing.T) {
 
 	// VERIFY
 	// UpdateState should never be called
-	mockPipelineRun.EXPECT().UpdateState(gomock.Any()).Times(0)
+	mockPipelineRun.EXPECT().UpdateState(gomock.Any(), gomock.Any()).Times(0)
 }
 
 func Test__runManager_copySecretsToRunNamespace__DoesCopySecret(t *testing.T) {

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -1291,7 +1291,7 @@ func Test__runManager_Start__CreatesTektonTaskRun(t *testing.T) {
 	examinee.testing = newRunManagerTestingWithRequiredStubs()
 
 	// EXERCISE
-	resultError := examinee.Start(mockPipelineRun, config)
+	_, resultError := examinee.Start(mockPipelineRun, config)
 	assert.NilError(t, resultError)
 
 	// VERIFY
@@ -1419,7 +1419,7 @@ func Test__runManager_Start__DoesNotSetPipelineRunStatus(t *testing.T) {
 	examinee.testing = newRunManagerTestingWithRequiredStubs()
 
 	// EXERCISE
-	resultError := examinee.Start(mockPipelineRun, config)
+	_, resultError := examinee.Start(mockPipelineRun, config)
 	assert.NilError(t, resultError)
 
 	// VERIFY

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -109,12 +109,12 @@ func Test__runManager_prepareRunNamespace__CreatesNamespaces(t *testing.T) {
 				pipelineRun1 := h.getPipelineRunFromStorage(cf, h.namespace1, h.pipelineRun1)
 				expectedNamespaces := []string{h.namespace1}
 
-				h.verifyNamespace(cf, pipelineRun1.Status.Namespace, "main")
-				expectedNamespaces = append(expectedNamespaces, pipelineRun1.Status.Namespace)
+				h.verifyNamespace(cf, runCtx.runNamespace, "main")
+				expectedNamespaces = append(expectedNamespaces, runCtx.runNamespace)
 
 				if ffEnabled {
-					h.verifyNamespace(cf, pipelineRun1.Status.AuxiliaryNamespace, "aux")
-					expectedNamespaces = append(expectedNamespaces, pipelineRun1.Status.AuxiliaryNamespace)
+					h.verifyNamespace(cf, runCtx.auxNamespace, "aux")
+					expectedNamespaces = append(expectedNamespaces, runCtx.auxNamespace)
 				} else {
 					assert.Equal(t, pipelineRun1.Status.AuxiliaryNamespace, "")
 				}
@@ -1291,7 +1291,7 @@ func Test__runManager_Start__CreatesTektonTaskRun(t *testing.T) {
 	examinee.testing = newRunManagerTestingWithRequiredStubs()
 
 	// EXERCISE
-	_, resultError := examinee.Start(mockPipelineRun, config)
+	_, _, resultError := examinee.Start(mockPipelineRun, config)
 	assert.NilError(t, resultError)
 
 	// VERIFY
@@ -1419,7 +1419,7 @@ func Test__runManager_Start__DoesNotSetPipelineRunStatus(t *testing.T) {
 	examinee.testing = newRunManagerTestingWithRequiredStubs()
 
 	// EXERCISE
-	_, resultError := examinee.Start(mockPipelineRun, config)
+	_, _, resultError := examinee.Start(mockPipelineRun, config)
 	assert.NilError(t, resultError)
 
 	// VERIFY

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -1492,7 +1492,7 @@ func Test__runManager_Cleanup__RemovesNamespaces(t *testing.T) {
 			}
 			err = examinee.prepareRunNamespace(runCtx)
 			assert.NilError(t, err)
-			err = runCtx.pipelineRun.CommitStatus()
+			_, err = runCtx.pipelineRun.CommitStatus()
 			assert.NilError(t, err)
 			{
 				pipelineRun1 := h.getPipelineRunFromStorage(cf, h.namespace1, h.pipelineRun1)


### PR DESCRIPTION
### Description

* Problem: from time to time we receive pipeline runs via build syncer with status "FINISHED", but without build result. This is (most likely) caused by non atomic updates (`state` is first changed and persisted, afterwards `result`).
  * Before that change a change has been applied to the memory representation and that change was persisted immediatly.
  * With that change a change is only applied to the memory representation. Other changes can be applied afterwards. There is a new `Commit()` function which needs to be called for persisting the changes. With that several changes can be persisted in one step. 

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
       Integration tests on mr2 were successfull (with #249)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
