### PR TITLE
Increase log level

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,14 @@
 - version: NEXT
   date: TBD
   changes:
+    - type: internal
+      impact: patch
+      title: Increase default log level
+      description: |-
+        Default log level was increaset to 3.
+        Small adjustments to log output.
+      pullRequestNumber: 0
+      jiraIssueNumber: CLOUDCIFEAT1-173
 
 - version: "0.13.1"
   date: 2021-09-27

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -57,7 +57,7 @@
       description: |-
         Default log level was increaset to 3.
         Small adjustments to log output.
-      pullRequestNumber: 0
+      pullRequestNumber: 254
       jiraIssueNumber: CLOUDCIFEAT1-173
 
 - version: "0.13.1"

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -10,7 +10,7 @@ runController:
     qps: 5
     burst: 10
     threadiness: 2
-    logVerbosity: 2
+    logVerbosity: 3
   image:
     repository: stewardci/stewardci-run-controller
     tag: "0.13.1" #Do not modify this line! RunController tag updated automatically

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -148,7 +148,7 @@ func (r *pipelineRun) GetSpec() *api.PipelineSpec {
 // Fails if a state is set already.
 func (r *pipelineRun) InitState() error {
 	r.ensureCopy()
-	klog.V(3).Infof("Init State [%s]", r.String())
+	klog.V(3).Infof("Set State to New [%s]", r.String())
 	return r.changeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 
 		if s.State != api.StateUndefined {
@@ -315,7 +315,7 @@ func (r *pipelineRun) updateFinalizers(finalizerList []string) error {
 	result, err := r.client.Update(r.apiObj)
 	end := time.Now()
 	elapsed := end.Sub(start)
-	klog.V(3).Infof("finish update finalizer after %s in %s", elapsed, r.apiObj.Name)
+	klog.V(4).Infof("finish update finalizer after %s in %s", elapsed, r.apiObj.Name)
 	if err != nil {
 		return errors.Wrap(err,
 			fmt.Sprintf("Failed to update finalizers [%s]", r.String()))


### PR DESCRIPTION
### Description

The default log level was increased to 3.
Some small changes in the log output.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
