### PR TITLE
fix metering for state new

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,15 @@
   date: TBD
   changes:
 
+    - type: bug
+       impact: patch
+       title: Fix metering current durations in state new
+       description: |-
+         Observing the current duration of the pipelineruns failed in state new.
+         It could not determine the start timestamp and returned the error:
+         "cannot observe StateItem if StartedAt is not set"
+       pullRequestNumber: 255
+
 - version: "0.13.1"
   date: 2021-09-27
   changes:

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -53,13 +53,13 @@
   changes:
 
     - type: bug
-       impact: patch
-       title: Fix metering current durations in state new
-       description: |-
-         Observing the current duration of the pipelineruns failed in state new.
-         It could not determine the start timestamp and returned the error:
-         "cannot observe StateItem if StartedAt is not set"
-       pullRequestNumber: 255
+      impact: patch
+      title: Fix metering current durations in state new
+      description: |-
+        Observing the current duration of the pipelineruns failed in state new.
+        It could not determine the start timestamp and returned the error:
+        "cannot observe StateItem if StartedAt is not set"
+      pullRequestNumber: 255
 
 - version: "0.13.1"
   date: 2021-09-27

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -54,11 +54,14 @@
 
     - type: bug
       impact: patch
-      title: Fix metering current durations in state new
+      title: Fix measuring ongoing state durations
       description: |-
-        Observing the current duration of the pipelineruns failed in state new.
-        It could not determine the start timestamp and returned the error:
-        "cannot observe StateItem if StartedAt is not set"
+        Measuring ongoing state duration failed for pipeline runs in state `new`
+        with error message:
+        
+        ```
+        cannot observe StateItem if StartedAt is not set
+        ```
       pullRequestNumber: 255
 
 - version: "0.13.1"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -120,7 +120,7 @@ func (metrics *metrics) ObserveDurationByState(state *api.StateItem) error {
 // ObserveOngoingStateDuration logs the duration of the current (unfinished) pipeline state.
 func (metrics *metrics) ObserveOngoingStateDuration(run *api.PipelineRun) error {
 	//state undefined is not processed yet and will be metered as new
-	if run.Status.State == api.StateUndefined {
+	if run.Status.State == api.StateUndefined || run.Status.State == api.StateNew {
 		if run.CreationTimestamp.IsZero() {
 			return fmt.Errorf("cannot observe pipeline run if creationTimestamp is not set")
 		}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -62,6 +62,13 @@ func Test_ObserveOngoingStateDuration_Success(t *testing.T) {
 			setStartedAt:  false,
 			expectedState: api.StateNew,
 		},
+		{
+			name:          "success_when_state_new",
+			state:         api.StateNew,
+			stateDuration: time.Hour * 2,
+			setStartedAt:  false,
+			expectedState: api.StateNew,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			// SETUP


### PR DESCRIPTION
### Description

The test case "success_when_state_new" failed with the error message: "cannot observe StateItem if StartedAt is not set".
In State new, we need to use the creation timestamp to get the start time.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
