### PR TITLE
Fix np when tekton finished and timestamp missing

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,11 +52,11 @@
   date: TBD
   changes:
 
-    - type: hotfix
+    - type: bug
       impact: patch
-      title: Fix nil pointer dereferece if tekton finished time is not set.
+      title: Fix nil pointer dereference when Tekton task run failed to create pod
       description: |-
-        Currently a nil pointer dereference error occures if a tekton task is finished but has no
+        Currently a nil pointer dereference error occures if a Tekton task is finished but has no
         finished time. This is fixed with this change.
       pullRequestNumber: 259
       jiraIssueNumber: 179

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -59,7 +59,7 @@
         Currently a nil pointer dereference error occures if a tekton task is finished but has no
         finished time. This is fixed with this change.
       pullRequestNumber: 259
-      jiraIssueNumber: 1110
+      jiraIssueNumber: 179
 
     - type: internal
       impact: patch

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -58,7 +58,8 @@
       description: |-
         Currently a nil pointer dereference error occures if a tekton task is finished but has no
         finished time. This is fixed with this change.
-       pullRequestNumber: 0
+       pullRequestNumber: 259
+       jiraIssueNumber: 1110
 
     - type: internal
       impact: patch

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,14 @@
   date: TBD
   changes:
 
+    - type: hotfix
+      impact: patch
+      title: Fix nil pointer dereferece if tekton finished time is not set.
+      description: |-
+        Currently a nil pointer dereference error occures if a tekton task is finished but has no
+        finished time. This is fixed with this change.
+       pullRequestNumber: 0
+
     - type: internal
       impact: patch
       title: Fix stewardci-example-pipelines repo branch name

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -58,8 +58,8 @@
       description: |-
         Currently a nil pointer dereference error occures if a tekton task is finished but has no
         finished time. This is fixed with this change.
-       pullRequestNumber: 259
-       jiraIssueNumber: 1110
+      pullRequestNumber: 259
+      jiraIssueNumber: 1110
 
     - type: internal
       impact: patch

--- a/pkg/runctl/run.go
+++ b/pkg/runctl/run.go
@@ -26,7 +26,20 @@ func (r *tektonRun) GetStartTime() *metav1.Time {
 
 // GetCompletionTime returns completion time of run if already completed
 func (r *tektonRun) GetCompletionTime() *metav1.Time {
-	return r.tektonTaskRun.Status.CompletionTime
+	completionTime := r.tektonTaskRun.Status.CompletionTime
+	if completionTime != nil {
+		return completionTime
+	}
+	condition := r.getSucceededCondition()
+	if condition != nil {
+		ltt := condition.LastTransitionTime.Inner
+		if !ltt.IsZero() {
+			return &ltt
+		}
+	}
+
+	now := metav1.Now()
+	return &now
 }
 
 // GetContainerInfo returns the state of the Jenkinsfile Runner container

--- a/pkg/runctl/run_test.go
+++ b/pkg/runctl/run_test.go
@@ -22,9 +22,7 @@ const (
 	completedFail             = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 1}}]}}`
 	completedValidationFailed = `{"status": {"conditions": [{"message": "message1", "reason": "TaskRunValidationFailed", "status": "False", "type": "Succeeded"}]}}`
 	//See issue https://github.com/SAP/stewardci-core/issues/? TODO: create public issue. internal: 21
-	timeout              = `{"status": {"conditions": [{"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"", "reason": "TaskRunTimeout", "status": "False", "type": "Succeeded"}]}}`
-	completionTimeSet    = `{"status": { "completionTime": "2019-05-14T08:24:49Z" } }`
-	completionTimeNotSet = `{"status": {}}`
+	timeout = `{"status": {"conditions": [{"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"", "reason": "TaskRunTimeout", "status": "False", "type": "Succeeded"}]}}`
 
 	realStartedBuild = `status:
   conditions:
@@ -87,6 +85,11 @@ const (
       message: %q
       startedAt: "2019-05-14T08:24:11Z"
 `
+	completionTimeSet = `status: 
+  completionTime: 2019-05-14T08:24:49Z
+  `
+	completionTimeNotSet = `status: {}`
+
 	conditionSuccessWithTransitionTime = `status:
   conditions:
   - lastTransitionTime: "2021-10-07T08:59:59Z"
@@ -185,15 +188,15 @@ func Test__IsFinished_Timeout(t *testing.T) {
 }
 
 func Test__GetCompletionTime(t *testing.T) {
-	for id, taskrun := range []*tekton.TaskRun{
-		fakeTektonTaskRun(completionTimeSet),
-		fakeTektonTaskRun(completionTimeNotSet),
-		fakeTektonTaskRunYaml(conditionSuccessWithTransitionTime),
-		fakeTektonTaskRunYaml(conditionSuccessWithoutTransitionTime),
-		fakeTektonTaskRunYaml(noSuccessCondition),
+	for id, taskrun := range []string{
+		completionTimeSet,
+		completionTimeNotSet,
+		conditionSuccessWithTransitionTime,
+		conditionSuccessWithoutTransitionTime,
+		noSuccessCondition,
 	} {
 		t.Run(fmt.Sprintf("%d", id), func(t *testing.T) {
-			run := NewRun(taskrun)
+			run := NewRun(fakeTektonTaskRunYaml(taskrun))
 			completionTime := run.GetCompletionTime()
 			assert.Assert(t, completionTime != nil)
 		})


### PR DESCRIPTION
### Description

The run controller hits a nil pointer dereference issue when a tekton task is finished but has no finished timestamp.
This can happen if e.g. the fetching of an image fails.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
