### PR TITLE
Reasonable names for runcontroller and tenantcontroller binaries

### DIFF
--- a/cmd/run_controller/Dockerfile
+++ b/cmd/run_controller/Dockerfile
@@ -4,13 +4,13 @@ RUN mkdir /build
 ADD . /build/
 WORKDIR /build
 RUN apk add --no-cache git
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main -v ./cmd/run_controller
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix cgo -ldflags '-extldflags "-static"' -o runcontroller -v ./cmd/run_controller
 RUN mkdir -p /result/app/
 RUN mkdir -p /result/tmp/
-RUN cp /build/main /result/app/
+RUN cp /build/runcontroller /result/app/
 
 
 FROM scratch
 COPY --from=builder /result/ /
 WORKDIR /app
-CMD ["./main"]
+CMD ["./runcontroller"]

--- a/cmd/tenant_controller/Dockerfile
+++ b/cmd/tenant_controller/Dockerfile
@@ -4,13 +4,13 @@ RUN mkdir /build
 ADD . /build/
 WORKDIR /build
 RUN apk add --no-cache git
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main -v ./cmd/tenant_controller
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix cgo -ldflags '-extldflags "-static"' -o tenantcontroller -v ./cmd/tenant_controller
 RUN mkdir -p /result/app/
 RUN mkdir -p /result/tmp/
-RUN cp /build/main /result/app/
+RUN cp /build/tenantcontroller /result/app/
 
 
 FROM scratch
 COPY --from=builder /result/ /
 WORKDIR /app
-CMD ["./main"]
+CMD ["./tenantcontroller"]


### PR DESCRIPTION
### Description

Up to now both binaries are names "main" which is confusing when we have to distinguish between both binaries.

**Note: I was not able to build the docker images locally, hence I was not able to test the images.**

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
