### PR TITLE
Fix improper error handling

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -160,6 +160,16 @@
         built in your context.
       pullRequestNumber: 284
 
+    - type: bug
+      impact: patch
+      title: Fix improper error handling
+      description: |-
+        In `pkg.k8s` the functions
+        `(*serviceAccountHelper) GetServiceAccountSecretName` and
+        `(*serviceAccountHelper) GetServiceAccountSecretNameRepeat` swallow
+        errors that can occur when performing K8s API calls.
+      pullRequestNumber: 287
+
 - version: "0.14.4"
   date: 2021-11-17
   changes:

--- a/pkg/k8s/serviceAccountHelper_test.go
+++ b/pkg/k8s/serviceAccountHelper_test.go
@@ -50,9 +50,10 @@ func Test_serviceAccountHelper_GetServiceAccountSecretName_works(t *testing.T) {
 	examinee := account.GetHelper()
 
 	// EXERCISE
-	result := examinee.GetServiceAccountSecretName(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretName(ctx)
 
 	// VERIFY
+	assert.NilError(t, resultErr)
 	assert.Equal(t, secretName, result)
 }
 
@@ -114,9 +115,10 @@ func Test_serviceAccountHelper_GetServiceAccountSecretNameRepeat_delayedRef_work
 	}()
 
 	// EXERCISE
-	result := examinee.GetServiceAccountSecretNameRepeat(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretNameRepeat(ctx)
 
 	// VERIFY
+	assert.NilError(t, resultErr)
 	assert.Equal(t, secretName, result)
 
 	waitGroup.Wait()
@@ -175,9 +177,10 @@ func Test_serviceAccountHelper_GetServiceAccountSecretNameRepeat_delayedSecret_w
 	}()
 
 	// EXERCISE
-	result := examinee.GetServiceAccountSecretNameRepeat(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretNameRepeat(ctx)
 
 	// VERIFY
+	assert.NilError(t, resultErr)
 	assert.Equal(t, secretName, result)
 
 	waitGroup.Wait()
@@ -222,10 +225,11 @@ func Test_serviceAccountHelper_GetServiceAccountSecretName_wrongType(t *testing.
 	examinee := account.GetHelper()
 
 	// EXERCISE
-	resultName := examinee.GetServiceAccountSecretName(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretName(ctx)
 
 	// VERIFY
-	assert.Equal(t, "", resultName)
+	assert.NilError(t, resultErr)
+	assert.Equal(t, "", result)
 }
 
 func Test_serviceAccountHelper_GetServiceAccountSecretName_refMissing(t *testing.T) {
@@ -266,10 +270,11 @@ func Test_serviceAccountHelper_GetServiceAccountSecretName_refMissing(t *testing
 	examinee := account.GetHelper()
 
 	// EXERCISE
-	resultName := examinee.GetServiceAccountSecretName(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretName(ctx)
 
 	// VERIFY
-	assert.Equal(t, "", resultName)
+	assert.NilError(t, resultErr)
+	assert.Equal(t, "", result)
 }
 
 func Test_serviceAccountHelper_GetServiceAccountSecretName_secretMissing(t *testing.T) {
@@ -304,8 +309,9 @@ func Test_serviceAccountHelper_GetServiceAccountSecretName_secretMissing(t *test
 	examinee := account.GetHelper()
 
 	// EXERCISE
-	resultName := examinee.GetServiceAccountSecretName(ctx)
+	result, resultErr := examinee.GetServiceAccountSecretName(ctx)
 
 	// VERIFY
-	assert.Equal(t, "", resultName)
+	assert.NilError(t, resultErr)
+	assert.Equal(t, "", result)
 }

--- a/pkg/k8s/serviceAccountManager.go
+++ b/pkg/k8s/serviceAccountManager.go
@@ -213,8 +213,8 @@ func (a *ServiceAccountWrap) GetServiceAccount() *v1.ServiceAccount {
 
 // ServiceAccountHelper implements functions to get service account secret
 type ServiceAccountHelper interface {
-	GetServiceAccountSecretNameRepeat(ctx context.Context) string
-	GetServiceAccountSecretName(ctx context.Context) string
+	GetServiceAccountSecretNameRepeat(ctx context.Context) (string, error)
+	GetServiceAccountSecretName(ctx context.Context) (string, error)
 }
 
 // GetHelper returns a ServiceAccountHelper

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -879,7 +879,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 func newTestRunManager(workFactory k8s.ClientFactory, secretProvider secrets.SecretProvider) run.Manager {
 	runManager := newRunManager(workFactory, secretProvider)
 	runManager.testing = &runManagerTesting{
-		getServiceAccountSecretNameStub: func(context.Context, *runContext) string { return "foo" },
+		getServiceAccountSecretNameStub: func(context.Context, *runContext) (string, error) { return "foo", nil },
 	}
 	return runManager
 }

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -45,7 +45,7 @@ func newRunManagerTestingWithAllNoopStubs() *runManagerTesting {
 	return &runManagerTesting{
 		cleanupStub:                               func(context.Context, *runContext) error { return nil },
 		copySecretsToRunNamespaceStub:             func(context.Context, *runContext) (string, []string, error) { return "", []string{}, nil },
-		getServiceAccountSecretNameStub:           func(context.Context, *runContext) string { return "" },
+		getServiceAccountSecretNameStub:           func(context.Context, *runContext) (string, error) { return "", nil },
 		setupLimitRangeFromConfigStub:             func(context.Context, *runContext) error { return nil },
 		setupNetworkPolicyFromConfigStub:          func(context.Context, *runContext) error { return nil },
 		setupNetworkPolicyThatIsolatesAllPodsStub: func(context.Context, *runContext) error { return nil },
@@ -59,7 +59,7 @@ func newRunManagerTestingWithAllNoopStubs() *runManagerTesting {
 
 func newRunManagerTestingWithRequiredStubs() *runManagerTesting {
 	return &runManagerTesting{
-		getServiceAccountSecretNameStub: func(context.Context, *runContext) string { return "" },
+		getServiceAccountSecretNameStub: func(context.Context, *runContext) (string, error) { return "", nil },
 	}
 }
 
@@ -1234,8 +1234,8 @@ func Test__runManager_createTektonTaskRun__PodTemplate_AllValuesSet(t *testing.T
 		factory: cf,
 		testing: newRunManagerTestingWithAllNoopStubs(),
 	}
-	examinee.testing.getServiceAccountSecretNameStub = func(_ context.Context, ctx *runContext) string {
-		return serviceAccountSecretName
+	examinee.testing.getServiceAccountSecretNameStub = func(_ context.Context, ctx *runContext) (string, error) {
+		return serviceAccountSecretName, nil
 	}
 
 	// EXERCISE


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
In `pkg.k8s` the functions `(*serviceAccountHelper) GetServiceAccountSecretName` and `(*serviceAccountHelper) GetServiceAccountSecretNameRepeat` swallow errors that can occur when performing K8s API calls.


### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- N/A (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
