### PR TITLE
Fix improper error handling

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -170,6 +170,15 @@
         errors that can occur when performing K8s API calls.
       pullRequestNumber: 287
 
+    - type: bug
+      impact: patch
+      title: Fix improper error handling
+      description: |-
+        The run controller did not put back a pipeline run into its work queue
+        for later retry if it was in state `running` but updating the resource
+        status failed.
+      pullRequestNumber: 288
+
 - version: "0.14.4"
   date: 2021-11-17
   changes:

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -389,7 +389,10 @@ func (c *Controller) syncHandler(key string) error {
 			return c.updateStateAndResult(ctx, pipelineRun, api.StateCleaning, result, *run.GetCompletionTime())
 		}
 		// commit container update
-		c.commitStatusAndMeter(ctx, pipelineRun)
+		err = c.commitStatusAndMeter(ctx, pipelineRun)
+		if err != nil {
+			return err
+		}
 
 	case api.StateCleaning:
 		err = runManager.Cleanup(ctx, pipelineRun)


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
The run controller does not put back a pipeline run into its work queue for later retry if it was in state `running` but updating the resource status failed.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
