### PR TITLE
Don't panic on invalid string argument

### DIFF
--- a/pkg/tenantctl/config.go
+++ b/pkg/tenantctl/config.go
@@ -2,7 +2,6 @@ package tenantctl
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 

--- a/pkg/tenantctl/config.go
+++ b/pkg/tenantctl/config.go
@@ -2,6 +2,7 @@ package tenantctl
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 
@@ -31,7 +32,7 @@ type clientConfigImpl struct {
 // getClientConfig returns the configurartion of the Steward client.
 func getClientConfig(ctx context.Context, factory k8s.ClientFactory, clientNamespace string) (clientConfig, error) {
 	if clientNamespace == "" {
-		panic("must provide a client namespace")
+		return nil, fmt.Errorf("invalid client namespace name: '%s'", clientNamespace)
 	}
 
 	newConfig := clientConfigImpl{

--- a/pkg/tenantctl/config.go
+++ b/pkg/tenantctl/config.go
@@ -32,7 +32,7 @@ type clientConfigImpl struct {
 // getClientConfig returns the configurartion of the Steward client.
 func getClientConfig(ctx context.Context, factory k8s.ClientFactory, clientNamespace string) (clientConfig, error) {
 	if clientNamespace == "" {
-		return nil, fmt.Errorf("invalid client namespace name: '%s'", clientNamespace)
+		return nil, errors.New("client namespace must not be empty")
 	}
 
 	newConfig := clientConfigImpl{

--- a/pkg/tenantctl/config_test.go
+++ b/pkg/tenantctl/config_test.go
@@ -104,7 +104,7 @@ func Test_getClientConfig_NamespaceParameterIsZeroLengthString(t *testing.T) {
 	result, resultErr := getClientConfig(ctx, cf, emptyNameString)
 
 	// VERIFY
-	assert.ErrorContains(t, resultErr, "invalid client namespace name: ''")
+	assert.ErrorContains(t, resultErr, "client namespace must not be empty")
 	assert.Assert(t, result == nil)
 }
 

--- a/pkg/tenantctl/config_test.go
+++ b/pkg/tenantctl/config_test.go
@@ -8,7 +8,6 @@ import (
 
 	fake "github.com/SAP/stewardci-core/pkg/k8s/fake"
 	assert "gotest.tools/assert"
-	cmp "gotest.tools/assert/cmp"
 	is "gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,9 +101,11 @@ func Test_getClientConfig_NamespaceParameterIsZeroLengthString(t *testing.T) {
 	)
 
 	// EXERCISE
-	assert.Assert(t, cmp.Panics(func() {
-		getClientConfig(ctx, cf, emptyNameString)
-	}))
+	result, resultErr := getClientConfig(ctx, cf, emptyNameString)
+
+	// VERIFY
+	assert.ErrorContains(t, resultErr, "invalid client namespace name: ''")
+	assert.Assert(t, result == nil)
 }
 
 func Test_getClientConfig_ClientNamespaceNotExisting(t *testing.T) {


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
Return an error instead.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- N/A [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
