### PR TITLE
Fix errors introduced by #290

### DIFF
--- a/test/builder/pipelineRun_test.go
+++ b/test/builder/pipelineRun_test.go
@@ -82,26 +82,33 @@ func Test_PipelineRunAbort(t *testing.T) {
 func Test_PipelineRunLoggingWithRunID(t *testing.T) {
 	buildID := uuid.New().String()
 	realmID := uuid.New().String()
-	pipelineRun := PipelineRun("prefix1", "namespace1",
+	pipelineRun := PipelineRun(
+		"prefix1",
+		"namespace1",
 		PipelineRunSpec(
 			LoggingWithRunID(&api.CustomJSON{
-				map[string]string{
+				Value: map[string]string{
 					"jobId":   "1",
 					"buildId": buildID,
 					"realmId": realmID,
-				}}),
+				},
+			}),
 		),
 	)
-	assert.DeepEqual(t, &api.Logging{
-		Elasticsearch: &api.Elasticsearch{
-			RunID: &api.CustomJSON{
-				map[string]string{
-					"jobId":   "1",
-					"buildId": buildID,
-					"realmId": realmID,
-				}},
+	assert.DeepEqual(t,
+		&api.Logging{
+			Elasticsearch: &api.Elasticsearch{
+				RunID: &api.CustomJSON{
+					Value: map[string]string{
+						"jobId":   "1",
+						"buildId": buildID,
+						"realmId": realmID,
+					},
+				},
+			},
 		},
-	}, pipelineRun.Spec.Logging)
+		pipelineRun.Spec.Logging,
+	)
 }
 
 func Test_PipelineRunLoggingIndexURL(t *testing.T) {
@@ -120,28 +127,35 @@ func Test_PipelineRunLoggingIndexURL(t *testing.T) {
 func Test_PipelineRunLoggingWithAllParams(t *testing.T) {
 	buildID := uuid.New().String()
 	realmID := uuid.New().String()
-	pipelineRun := PipelineRun("prefix1", "namespace1",
+	pipelineRun := PipelineRun(
+		"prefix1",
+		"namespace1",
 		PipelineRunSpec(
 			LoggingWithIndexURL("testURL"),
 			LoggingWithRunID(&api.CustomJSON{
-				map[string]string{
+				Value: map[string]string{
 					"jobId":   "1",
 					"buildId": buildID,
 					"realmId": realmID,
-				}}),
+				},
+			}),
 		),
 	)
-	assert.DeepEqual(t, &api.Logging{
-		Elasticsearch: &api.Elasticsearch{
-			IndexURL: "testURL",
-			RunID: &api.CustomJSON{
-				map[string]string{
-					"jobId":   "1",
-					"buildId": buildID,
-					"realmId": realmID,
-				}},
+	assert.DeepEqual(t,
+		&api.Logging{
+			Elasticsearch: &api.Elasticsearch{
+				IndexURL: "testURL",
+				RunID: &api.CustomJSON{
+					Value: map[string]string{
+						"jobId":   "1",
+						"buildId": buildID,
+						"realmId": realmID,
+					},
+				},
+			},
 		},
-	}, pipelineRun.Spec.Logging)
+		pipelineRun.Spec.Logging,
+	)
 }
 
 func Test_CheckConflictsBetweenIndexURLsOfTests(t *testing.T) {
@@ -154,32 +168,38 @@ func Test_CheckConflictsBetweenIndexURLsOfTests(t *testing.T) {
 	}{
 		{
 			name: "pipelineRun with runID, indexURL and credential",
-			pipelineRun: PipelineRun("prefix1", "namespace1",
+			pipelineRun: PipelineRun(
+				"prefix1",
+				"namespace1",
 				PipelineRunSpec(
 					LoggingWithIndexURL("foo"),
 					LoggingWithRunID(&api.CustomJSON{
-						map[string]string{
+						Value: map[string]string{
 							"jobId":   "1",
 							"buildId": buildID,
 							"realmId": realmID,
-						}}),
+						},
+					}),
 				),
 			),
 			expectedResult: &api.Logging{
 				Elasticsearch: &api.Elasticsearch{
 					IndexURL: "foo",
 					RunID: &api.CustomJSON{
-						map[string]string{
+						Value: map[string]string{
 							"jobId":   "1",
 							"buildId": buildID,
 							"realmId": realmID,
-						}},
+						},
+					},
 				},
 			},
 		},
 		{
 			name: "pipelineRun with different indexURL than previous test",
-			pipelineRun: PipelineRun("prefix1", "namespace1",
+			pipelineRun: PipelineRun(
+				"prefix1",
+				"namespace1",
 				PipelineRunSpec(
 					LoggingWithIndexURL("bar"),
 				),

--- a/test/framework/framework_test.go
+++ b/test/framework/framework_test.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	"github.com/SAP/stewardci-core/test/builder"
+	"github.com/SAP/stewardci-core/test/shared"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -20,8 +21,6 @@ var frameworkTestBuilders = []PipelineRunTestBuilder{
 	PipelineRunWrongName,
 	PipelineRunWithSecretNameConflict,
 }
-
-const pipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
 
 func Test_FirstFinishBeforeSecondStarts(t *testing.T) {
 	test := TestPlan{TestBuilder: PipelineRunWrongName,
@@ -51,8 +50,8 @@ func PipelineRunSleepTooLong(Namespace string, runID *api.CustomJSON) PipelineRu
 		PipelineRun: builder.PipelineRun("sleeptoolong-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"sleep/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"sleep/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SLEEP_FOR_SECONDS", "10"),
 			)),
 		Check:    PipelineRunHasStateResult(api.ResultSuccess),
@@ -67,8 +66,8 @@ func PipelineRunWrongExpect(Namespace string, runID *api.CustomJSON) PipelineRun
 		PipelineRun: builder.PipelineRun("wrongexpect-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"success/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"success/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:    PipelineRunHasStateResult(api.ResultAborted),
 		Timeout:  120 * time.Second,
@@ -82,8 +81,8 @@ func PipelineRunWrongName(Namespace string, runID *api.CustomJSON) PipelineRunTe
 		PipelineRun: builder.PipelineRun("wrong_Name", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"success/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"success/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:    PipelineRunHasStateResult(api.ResultSuccess),
 		Timeout:  120 * time.Second,
@@ -97,8 +96,8 @@ func PipelineRunWithSecretNameConflict(Namespace string, runID *api.CustomJSON) 
 		PipelineRun: builder.PipelineRun("with-secret-name-conflict", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   PipelineRunHasStateResult(api.ResultSuccess),
 		Timeout: 120 * time.Second,

--- a/test/integrationtest/pipelineRun_testbuilders.go
+++ b/test/integrationtest/pipelineRun_testbuilders.go
@@ -6,6 +6,7 @@ import (
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	builder "github.com/SAP/stewardci-core/test/builder"
 	f "github.com/SAP/stewardci-core/test/framework"
+	"github.com/SAP/stewardci-core/test/shared"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -25,11 +26,6 @@ var AllTestBuilders = []f.PipelineRunTestBuilder{
 	PipelineRunWrongJenkinsfileRepoWithUser,
 }
 
-const (
-	pipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
-	pipelineRepoRevision = "main"
-)
-
 // PipelineRunAbort is a PipelineRunTestBuilder to build a PipelineRunTest with aborted pipeline
 func PipelineRunAbort(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 	return f.PipelineRunTest{
@@ -37,8 +33,8 @@ func PipelineRunAbort(Namespace string, runID *api.CustomJSON) f.PipelineRunTest
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
 				builder.Abort(),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"sleep/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"sleep/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultAborted),
 		Timeout: 15 * time.Second,
@@ -52,8 +48,8 @@ func PipelineRunSleep(Namespace string, runID *api.CustomJSON) f.PipelineRunTest
 		PipelineRun: builder.PipelineRun("sleep-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"sleep/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"sleep/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SLEEP_FOR_SECONDS", "1"),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultSuccess),
@@ -67,8 +63,8 @@ func PipelineRunFail(Namespace string, runID *api.CustomJSON) f.PipelineRunTest 
 		PipelineRun: builder.PipelineRun("error-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"error/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"error/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultErrorContent),
 		Timeout: 600 * time.Second,
@@ -81,8 +77,8 @@ func PipelineRunOK(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
 		PipelineRun: builder.PipelineRun("ok-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"success/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"success/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 
 				builder.RunDetails("myJobName1", "myCause1", 17),
 			)),
@@ -97,8 +93,8 @@ func PipelineRunK8SPlugin(Namespace string, runID *api.CustomJSON) f.PipelineRun
 		PipelineRun: builder.PipelineRun("k8s-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"k8sPlugin/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"k8sPlugin/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 
 				builder.RunDetails("myK8SJob1", "myCause1", 18),
 			)),
@@ -113,8 +109,8 @@ func PipelineRunWithSecret(Namespace string, runID *api.CustomJSON) f.PipelineRu
 		PipelineRun: builder.PipelineRun("with-secret-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SECRETID", "with-secret-foo"),
 				builder.ArgSpec("EXPECTEDUSER", "bar"),
 				builder.ArgSpec("EXPECTEDPWD", "baz"),
@@ -132,8 +128,8 @@ func PipelineRunWithSecretRename(Namespace string, runID *api.CustomJSON) f.Pipe
 		PipelineRun: builder.PipelineRun("with-secret-rename-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SECRETID", "renamed-secret-new-name"),
 				builder.ArgSpec("EXPECTEDUSER", "bar"),
 				builder.ArgSpec("EXPECTEDPWD", "baz"),
@@ -152,8 +148,8 @@ func PipelineRunWithSecretInvalidRename(Namespace string, runID *api.CustomJSON)
 		PipelineRun: builder.PipelineRun("with-secret-invalid-rename-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SECRETID", "InvalidName"),
 				builder.ArgSpec("EXPECTEDUSER", "bar"),
 				builder.ArgSpec("EXPECTEDPWD", "baz"),
@@ -172,8 +168,8 @@ func PipelineRunWithSecretRenameDuplicate(Namespace string, runID *api.CustomJSO
 		PipelineRun: builder.PipelineRun("with-secret-duplicate-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile",pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SECRETID", "duplicate"),
 				builder.ArgSpec("EXPECTEDUSER", "bar"),
 				builder.ArgSpec("EXPECTEDPWD", "baz"),
@@ -196,8 +192,8 @@ func PipelineRunMissingSecret(Namespace string, runID *api.CustomJSON) f.Pipelin
 		PipelineRun: builder.PipelineRun("missing-secret-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"secret/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"secret/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 				builder.ArgSpec("SECRETID", "foo"),
 				builder.ArgSpec("EXPECTEDUSER", "bar"),
 				builder.ArgSpec("EXPECTEDPWD", "baz"),
@@ -215,7 +211,7 @@ func PipelineRunWrongJenkinsfileRepo(Namespace string, runID *api.CustomJSON) f.
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
-					"Jenkinsfile", pipelineRepoRevision),
+					"Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultErrorContent),
 		Timeout: 300 * time.Second,
@@ -229,7 +225,7 @@ func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string, runID *api.Custom
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
-					"Jenkinsfile", pipelineRepoRevision,
+					"Jenkinsfile", shared.ExamplePipelineRepoRevision,
 					builder.RepoAuthSecret("repo-auth"),
 				),
 			)),
@@ -245,8 +241,8 @@ func PipelineRunWrongJenkinsfilePath(Namespace string, runID *api.CustomJSON) f.
 		PipelineRun: builder.PipelineRun("wrong-jenkinsfile-path-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"not_existing_path/Jenkinsfile", pipelineRepoRevision),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"not_existing_path/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check: f.PipelineRunMessageOnFinished(`Command ['/app/bin/jenkinsfile-runner' '-w' '/app/jenkins' '-p' '/usr/share/jenkins/ref/plugins' '--runHome' '/jenkins_home' '--no-sandbox' '--build-number' '1' '-f' 'not_existing_path/Jenkinsfile'] failed with exit code 255
 Error output:

--- a/test/networkpolicy/pipelineRun_testbuilders.go
+++ b/test/networkpolicy/pipelineRun_testbuilders.go
@@ -6,9 +6,8 @@ import (
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	builder "github.com/SAP/stewardci-core/test/builder"
 	f "github.com/SAP/stewardci-core/test/framework"
+	"github.com/SAP/stewardci-core/test/shared"
 )
-
-const pipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
 
 // PipelineRunNetworkClosedPolicy is a PipelineRunTestBuilder to build a PipelineRunTest to check network policy
 func PipelineRunNetworkClosedPolicy(Namespace string, runID *api.CustomJSON) f.PipelineRunTest {
@@ -16,8 +15,8 @@ func PipelineRunNetworkClosedPolicy(Namespace string, runID *api.CustomJSON) f.P
 		PipelineRun: builder.PipelineRun("net-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"netcat/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"netcat/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultErrorContent),
 		Timeout: 600 * time.Second,
@@ -30,8 +29,8 @@ func PipelineRunNetworkOpenPolicy(Namespace string, runID *api.CustomJSON) f.Pip
 		PipelineRun: builder.PipelineRun("net-", Namespace,
 			builder.PipelineRunSpec(
 				builder.LoggingWithRunID(runID),
-				builder.JenkinsFileSpec(pipelineRepoURL,
-					"netcat/Jenkinsfile"),
+				builder.JenkinsFileSpec(shared.ExamplePipelineRepoURL,
+					"netcat/Jenkinsfile", shared.ExamplePipelineRepoRevision),
 			)),
 		Check:   f.PipelineRunHasStateResult(api.ResultSuccess),
 		Timeout: 600 * time.Second,

--- a/test/shared/constants.go
+++ b/test/shared/constants.go
@@ -1,0 +1,11 @@
+package shared
+
+const (
+	// ExamplePipelineRepoURL is the URL of a Git repository with example
+	// Steward pipeline run manifests.
+	ExamplePipelineRepoURL = "https://github.com/SAP-samples/stewardci-example-pipelines"
+
+	// ExamplePipelineRepoRevision is the revision of ExamplePipelineRepoURL
+	// to be used by tests.
+	ExamplePipelineRepoRevision = "main"
+)


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
#290 has introduced compile errors.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- N/A [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
