### PR TITLE
Remove use of deprecated K8s APIs

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -62,7 +62,18 @@
         - `apiextensions.k8s.io/v1beta1` → `apiextensions.k8s.io/v1`
         - `rbac.authorization.k8s.io/v1beta1` → `rbac.authorization.k8s.io/v1`
       warning: |-
-        Steward does no longer run on Kubernetes v1.15 or below.
+        -   Steward does no longer run on Kubernetes v1.15 or below.
+
+        -   Rolling back to an earlier version of Steward might fail.
+
+            All Steward releases up to v0.16.0 have a bug in the CRD update
+            hook of the Helm chart.
+            Using `helm rollback` or `helm upgrade` with such target version
+            will fail.
+
+            The problem has been fixed in Steward v0.16.1 and higher.
+            Rolling back to an earlier version can be achieved by first rolling
+            back to v0.16.1 and then to the desired target version.
       upgradeNotes: |-
         See the warnings section.
       pullRequestNumber: 296

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,21 @@
   date: TBD
   changes:
 
+    - type: enhancement
+      impact: incompatible
+      title: Remove use of deprecated K8s APIs
+      description: |-
+        Steward used some Kubernetes API versions that are deprecated in newer
+        Kubernetes releases.
+        The following replacements have been applied:
+        - `apiextensions.k8s.io/v1beta1` → `apiextensions.k8s.io/v1`
+        - `rbac.authorization.k8s.io/v1beta1` → `rbac.authorization.k8s.io/v1`
+      warning: |-
+        Steward does no longer run on Kubernetes v1.15 or below.
+      upgradeNotes: |-
+        See the warnings section.
+      pullRequestNumber: 296
+
 - version: "0.16.0"
   date: 2021-12-08
   changes:

--- a/charts/steward/Chart.yaml
+++ b/charts/steward/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.16.1-dev
+version: 0.17.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.16.1-dev
+appVersion: 0.17.0-dev

--- a/charts/steward/crds/pipelineruns.yaml
+++ b/charts/steward/crds/pipelineruns.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineruns.steward.sap.com
 spec:
   group: steward.sap.com
-  version: v1alpha1
   names:
     kind: PipelineRun
     singular: pipelinerun
@@ -13,96 +12,106 @@ spec:
     - spr
     - sprs
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec: ###
+            type: object
+            required:
+            - jenkinsFile
+            properties:
+              jenkinsFile: ###
+                type: object
+                required:
+                - repoUrl
+                - revision
+                - relativePath
+                properties:
+                  repoUrl: ###
+                    type: string
+                    pattern: '^[^\s]{1,}.*$'
+                  revision: ###
+                    type: string
+                    pattern: '^[^\s]{1,}.*$'
+                  relativePath: ###
+                    type: string
+                    pattern: '^[^\s]{1,}.*$'
+                  repoAuthSecret: ###
+                    type: string
+              args: ### map[string]string
+                type: object
+                additionalProperties: ###
+                  type: string
+              secrets: ###
+                type: array
+                items:
+                  type: string
+                  pattern: '^[^\s]{1,}.*$'
+              imagePullSecrets: ###
+                type: array
+                items:
+                  type: string
+                  pattern: '^[^\s]{1,}.*$'
+              intent: ###
+                type: string
+                pattern: '^(|run|abort)$'
+              logging: ###
+                type: object
+                properties:
+                  elasticsearch: ###
+                    type: object
+                    required:
+                    - runID
+                    properties:
+                      runID: ###
+                        type: object # should be any JSON value as soon as Elasticsearch Log Plug-in can handle it
+                        x-kubernetes-preserve-unknown-fields: true
+              runDetails: ###
+                type: object
+                properties:
+                  jobName: ###
+                    type: string
+                    #pattern: #TODO: valid Jenkins job names + blank
+                  sequenceNumber: ###
+                    type: integer
+                    minimum: 0
+                    maximum: 2147483647 # int32
+                  cause: ###
+                    type: string
+    subresources:
+      status: {}
+    additionalPrinterColumns:
     - name: Started
       type: date
-      JSONPath: .metadata.creationTimestamp
+      jsonPath: |-
+        .metadata.creationTimestamp
     - name: Finished
       type: date
-      JSONPath: .status.container.terminated.finishedAt
+      jsonPath: |-
+        .status.container.terminated.finishedAt
       priority: 1
     - name: Status
       type: string
       description: The current state of the pipeline run
-      JSONPath: .status.state
+      jsonPath: |-
+        .status.state
       priority: 0
     - name: Result
       type: string
       description: The result of the pipeline run
-      JSONPath: .status.result
+      jsonPath: |-
+        .status.result
       priority: 1
     - name: Message
       type: string
       description: The message of the pipeline run
-      JSONPath: .status.messageShort
+      jsonPath: |-
+        .status.messageShort
       priority: 2
-  validation:
-    openAPIV3Schema:
-      type: object
-      required:
-        - spec
-      properties:
-        spec: ###
-          type: object
-          required:
-            - jenkinsFile
-          properties:
-            jenkinsFile: ###
-              type: object
-              required:
-                - repoUrl
-                - revision
-                - relativePath
-              properties:
-                repoUrl: ###
-                  type: string
-                  pattern: '^[^\s]{1,}.*$'
-                revision: ###
-                  type: string
-                  pattern: '^[^\s]{1,}.*$'
-                relativePath: ###
-                  type: string
-                  pattern: '^[^\s]{1,}.*$'
-                repoAuthSecret: ###
-                  type: string
-            args: ### map[string]string
-              type: object
-              additionalProperties: ###
-                type: string
-            secrets: ###
-              type: array
-              items:
-                type: string
-                pattern: '^[^\s]{1,}.*$'
-            imagePullSecrets: ###
-              type: array
-              items:
-                type: string
-                pattern: '^[^\s]{1,}.*$'
-            intent: ###
-              type: string
-              pattern: '^(|run|abort)$'
-            logging: ###
-              type: object
-              properties:
-                elasticsearch: ###
-                  type: object
-                  required:
-                    - runID
-                  properties:
-                    runID: ###
-                      type: object # should be any JSON value as soon as Elasticsearch Log Plug-in can handle it
-            runDetails: ###
-              type: object
-              properties:
-                jobName: ###
-                  type: string
-                  #pattern: #TODO: valid Jenkins job names + blank
-                sequenceNumber: ###
-                  type: integer
-                  minimum: 0
-                  maximum: 2147483647 # int32
-                cause: ###
-                  type: string

--- a/charts/steward/crds/pipelineruns.yaml
+++ b/charts/steward/crds/pipelineruns.yaml
@@ -12,7 +12,6 @@ spec:
     - spr
     - sprs
   scope: Namespaced
-  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true

--- a/charts/steward/crds/pipelineruns.yaml
+++ b/charts/steward/crds/pipelineruns.yaml
@@ -12,6 +12,7 @@ spec:
     - spr
     - sprs
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true
@@ -22,69 +23,92 @@ spec:
         required:
         - spec
         properties:
-          spec: ###
+          "spec": ###
             type: object
             required:
             - jenkinsFile
             properties:
-              jenkinsFile: ###
+              "jenkinsfileRunner": ###
+                type: object
+                properties:
+                  "image": ###
+                    type: string
+                  "imagePullPolicy": ###
+                    type: string
+                    enum:
+                    - ""
+                    - Never
+                    - IfNotPresent
+                    - Always
+              "jenkinsFile": ###
                 type: object
                 required:
                 - repoUrl
                 - revision
                 - relativePath
                 properties:
-                  repoUrl: ###
+                  "repoUrl": ###
                     type: string
                     pattern: '^[^\s]{1,}.*$'
-                  revision: ###
+                  "revision": ###
                     type: string
                     pattern: '^[^\s]{1,}.*$'
-                  relativePath: ###
+                  "relativePath": ###
                     type: string
                     pattern: '^[^\s]{1,}.*$'
-                  repoAuthSecret: ###
+                  "repoAuthSecret": ###
                     type: string
-              args: ### map[string]string
+              "args": ### map[string]string
                 type: object
                 additionalProperties: ###
                   type: string
-              secrets: ###
+              "secrets": ###
                 type: array
                 items:
                   type: string
                   pattern: '^[^\s]{1,}.*$'
-              imagePullSecrets: ###
+              "imagePullSecrets": ###
                 type: array
                 items:
                   type: string
                   pattern: '^[^\s]{1,}.*$'
-              intent: ###
+              "intent": ###
                 type: string
-                pattern: '^(|run|abort)$'
-              logging: ###
+                enum:
+                - ""
+                - run
+                - abort
+                default: run
+              "logging": ###
                 type: object
                 properties:
-                  elasticsearch: ###
+                  "elasticsearch": ###
                     type: object
                     required:
                     - runID
                     properties:
-                      runID: ###
+                      "runID": ###
                         type: object # should be any JSON value as soon as Elasticsearch Log Plug-in can handle it
                         x-kubernetes-preserve-unknown-fields: true
-              runDetails: ###
+                      "indexURL": ###
+                        type: string
+                      "authSecret": ###
+                        type: string
+              "runDetails": ###
                 type: object
                 properties:
-                  jobName: ###
+                  "jobName": ###
                     type: string
                     #pattern: #TODO: valid Jenkins job names + blank
-                  sequenceNumber: ###
+                  "sequenceNumber": ###
                     type: integer
                     minimum: 0
                     maximum: 2147483647 # int32
-                  cause: ###
+                  "cause": ###
                     type: string
+          "status": ###
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/charts/steward/crds/tenants.yaml
+++ b/charts/steward/crds/tenants.yaml
@@ -12,6 +12,7 @@ spec:
     - stn
     - stns
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true
@@ -19,7 +20,10 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        required: []
+        properties:
+          "status":
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/charts/steward/crds/tenants.yaml
+++ b/charts/steward/crds/tenants.yaml
@@ -12,7 +12,6 @@ spec:
     - stn
     - stns
   scope: Namespaced
-  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true

--- a/charts/steward/crds/tenants.yaml
+++ b/charts/steward/crds/tenants.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tenants.steward.sap.com
 spec:
   group: steward.sap.com
-  version: v1alpha1
   names:
     kind: Tenant
     singular: tenant
@@ -13,28 +12,37 @@ spec:
     - stn
     - stns
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    priority: 1
-  - name: Message
-    type: string
-    JSONPath: ".status.conditions[?(@.type==\"Ready\")].message"
-    priority: 1
-  - name: Tenant-Namespace
-    type: string
-    description: The name of the namespace for this tenant.
-    JSONPath: .status.tenantNamespaceName
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: []
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: []
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: |-
+        .status.conditions[?(@.type=="Ready")].status
+    - name: Reason
+      type: string
+      jsonPath: |-
+        .status.conditions[?(@.type=="Ready")].reason
+      priority: 1
+    - name: Message
+      type: string
+      jsonPath: |-
+        .status.conditions[?(@.type=="Ready")].message
+      priority: 1
+    - name: Tenant-Namespace
+      type: string
+      description: The name of the namespace for this tenant.
+      jsonPath: |-
+        .status.tenantNamespaceName
+    - name: Age
+      type: date
+      jsonPath: |-
+        .metadata.creationTimestamp

--- a/charts/steward/templates/clusterrole-client.yaml
+++ b/charts/steward/templates/clusterrole-client.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: steward-client
   labels:

--- a/charts/steward/templates/clusterrole-run.yaml
+++ b/charts/steward/templates/clusterrole-run.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: steward-run
   labels:

--- a/charts/steward/templates/clusterrole-tenant.yaml
+++ b/charts/steward/templates/clusterrole-tenant.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: steward-tenant
   labels:

--- a/charts/steward/templates/clusterrolebinding-run-controller.yaml
+++ b/charts/steward/templates/clusterrolebinding-run-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: steward-run-controller

--- a/pkg/k8s/clientFactory.go
+++ b/pkg/k8s/clientFactory.go
@@ -3,17 +3,17 @@ package k8s
 import (
 	"time"
 
-	steward "github.com/SAP/stewardci-core/pkg/client/clientset/versioned"
-	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/client/clientset/versioned/typed/steward/v1alpha1"
-	stewardinformer "github.com/SAP/stewardci-core/pkg/client/informers/externalversions"
-	tektonclient "github.com/SAP/stewardci-core/pkg/tektonclient/clientset/versioned"
-	tektonclientv1beta1 "github.com/SAP/stewardci-core/pkg/tektonclient/clientset/versioned/typed/pipeline/v1beta1"
+	stewardclients "github.com/SAP/stewardci-core/pkg/client/clientset/versioned"
+	stewardv1alpha1client "github.com/SAP/stewardci-core/pkg/client/clientset/versioned/typed/steward/v1alpha1"
+	stewardinformers "github.com/SAP/stewardci-core/pkg/client/informers/externalversions"
+	tektonclients "github.com/SAP/stewardci-core/pkg/tektonclient/clientset/versioned"
+	tektonv1beta1client "github.com/SAP/stewardci-core/pkg/tektonclient/clientset/versioned/typed/pipeline/v1beta1"
 	tektoninformers "github.com/SAP/stewardci-core/pkg/tektonclient/informers/externalversions"
 	dynamic "k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	networkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
-	rbacv1beta1 "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	klog "k8s.io/klog/v2"
 )
@@ -21,25 +21,25 @@ import (
 // ClientFactory is the interface for Kubernet client factories.
 type ClientFactory interface {
 	// CoreV1 returns the core/v1 Kubernetes client
-	CoreV1() corev1.CoreV1Interface
+	CoreV1() corev1client.CoreV1Interface
 
 	// NetworkingV1 returns the networking/v1 Kubernetes client
-	NetworkingV1() networkingv1.NetworkingV1Interface
+	NetworkingV1() networkingv1client.NetworkingV1Interface
 
-	// RbacV1beta1 returns the rbac/v1beta1 Kubernetes client
-	RbacV1beta1() rbacv1beta1.RbacV1beta1Interface
+	// RbacV1 returns the rbac/v1 Kubernetes client
+	RbacV1() rbacv1client.RbacV1Interface
 
 	// Dynamic returns the dynamic Kubernetes client
 	Dynamic() dynamic.Interface
 
 	// StewardV1alpha1 returns the steward.sap.com/v1alpha1 Kubernetes client
-	StewardV1alpha1() stewardv1alpha1.StewardV1alpha1Interface
+	StewardV1alpha1() stewardv1alpha1client.StewardV1alpha1Interface
 
 	// StewardInformerFactory returns the informer factory for Steward
-	StewardInformerFactory() stewardinformer.SharedInformerFactory
+	StewardInformerFactory() stewardinformers.SharedInformerFactory
 
 	// TektonV1beta1 returns the tekton.dev/v1beta1 Kubernetes client
-	TektonV1beta1() tektonclientv1beta1.TektonV1beta1Interface
+	TektonV1beta1() tektonv1beta1client.TektonV1beta1Interface
 
 	// TektonInformerFactory returns the informer factory for Tekton
 	TektonInformerFactory() tektoninformers.SharedInformerFactory
@@ -48,20 +48,20 @@ type ClientFactory interface {
 type clientFactory struct {
 	kubernetesClientset    *kubernetes.Clientset
 	dynamicClient          dynamic.Interface
-	stewardClientset       *steward.Clientset
-	stewardInformerFactory stewardinformer.SharedInformerFactory
-	tektonClientset        *tektonclient.Clientset
+	stewardClientset       *stewardclients.Clientset
+	stewardInformerFactory stewardinformers.SharedInformerFactory
+	tektonClientset        *tektonclients.Clientset
 	tektonInformerFactory  tektoninformers.SharedInformerFactory
 }
 
 // NewClientFactory creates new client factory based on rest config
 func NewClientFactory(config *rest.Config, resyncPeriod time.Duration) ClientFactory {
-	stewardClientset, err := steward.NewForConfig(config)
+	stewardClientset, err := stewardclients.NewForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "could not create Steward clientset: %s")
 		return nil
 	}
-	stewardInformerFactory := stewardinformer.NewSharedInformerFactory(stewardClientset, resyncPeriod)
+	stewardInformerFactory := stewardinformers.NewSharedInformerFactory(stewardClientset, resyncPeriod)
 
 	kubernetesClientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -75,7 +75,7 @@ func NewClientFactory(config *rest.Config, resyncPeriod time.Duration) ClientFac
 		return nil
 	}
 
-	tektonClientset, err := tektonclient.NewForConfig(config)
+	tektonClientset, err := tektonclients.NewForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "could not create Tekton clientset: %s")
 		return nil
@@ -93,17 +93,17 @@ func NewClientFactory(config *rest.Config, resyncPeriod time.Duration) ClientFac
 }
 
 // StewardInformerFactory implements interface ClientFactory
-func (f *clientFactory) StewardInformerFactory() stewardinformer.SharedInformerFactory {
+func (f *clientFactory) StewardInformerFactory() stewardinformers.SharedInformerFactory {
 	return f.stewardInformerFactory
 }
 
 // StewardV1alpha1 implements interface ClientFactory
-func (f *clientFactory) StewardV1alpha1() stewardv1alpha1.StewardV1alpha1Interface {
+func (f *clientFactory) StewardV1alpha1() stewardv1alpha1client.StewardV1alpha1Interface {
 	return f.stewardClientset.StewardV1alpha1()
 }
 
 // CoreV1 implements interface ClientFactory
-func (f *clientFactory) CoreV1() corev1.CoreV1Interface {
+func (f *clientFactory) CoreV1() corev1client.CoreV1Interface {
 	return f.kubernetesClientset.CoreV1()
 }
 
@@ -113,13 +113,13 @@ func (f *clientFactory) Dynamic() dynamic.Interface {
 }
 
 // NetworkingV1 implements interface ClientFactory
-func (f *clientFactory) NetworkingV1() networkingv1.NetworkingV1Interface {
+func (f *clientFactory) NetworkingV1() networkingv1client.NetworkingV1Interface {
 	return f.kubernetesClientset.NetworkingV1()
 }
 
-// RbacV1beta1 implements interface ClientFactory
-func (f *clientFactory) RbacV1beta1() rbacv1beta1.RbacV1beta1Interface {
-	return f.kubernetesClientset.RbacV1beta1()
+// RbacV1 implements interface ClientFactory
+func (f *clientFactory) RbacV1() rbacv1client.RbacV1Interface {
+	return f.kubernetesClientset.RbacV1()
 }
 
 // TektonInformerFactory implements interface ClientFactory
@@ -128,6 +128,6 @@ func (f *clientFactory) TektonInformerFactory() tektoninformers.SharedInformerFa
 }
 
 // TektonV1beta1 implements interface ClientFactory
-func (f *clientFactory) TektonV1beta1() tektonclientv1beta1.TektonV1beta1Interface {
+func (f *clientFactory) TektonV1beta1() tektonv1beta1client.TektonV1beta1Interface {
 	return f.tektonClientset.TektonV1beta1()
 }

--- a/pkg/k8s/fake/clusterRole.go
+++ b/pkg/k8s/fake/clusterRole.go
@@ -1,11 +1,15 @@
 package fake
 
 import (
-	v1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterRole creates a fake ClusterRole with defined name
-func ClusterRole(name string) *v1beta1.ClusterRole {
-	return &v1beta1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}}
+func ClusterRole(name string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
 }

--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -40,7 +40,7 @@ import (
 	dynamic "k8s.io/client-go/dynamic"
 	v11 "k8s.io/client-go/kubernetes/typed/core/v1"
 	v12 "k8s.io/client-go/kubernetes/typed/networking/v1"
-	v1beta10 "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
+	v13 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	reflect "reflect"
 )
 
@@ -109,18 +109,18 @@ func (mr *MockClientFactoryMockRecorder) NetworkingV1() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkingV1", reflect.TypeOf((*MockClientFactory)(nil).NetworkingV1))
 }
 
-// RbacV1beta1 mocks base method
-func (m *MockClientFactory) RbacV1beta1() v1beta10.RbacV1beta1Interface {
+// RbacV1 mocks base method
+func (m *MockClientFactory) RbacV1() v13.RbacV1Interface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RbacV1beta1")
-	ret0, _ := ret[0].(v1beta10.RbacV1beta1Interface)
+	ret := m.ctrl.Call(m, "RbacV1")
+	ret0, _ := ret[0].(v13.RbacV1Interface)
 	return ret0
 }
 
-// RbacV1beta1 indicates an expected call of RbacV1beta1
-func (mr *MockClientFactoryMockRecorder) RbacV1beta1() *gomock.Call {
+// RbacV1 indicates an expected call of RbacV1
+func (mr *MockClientFactoryMockRecorder) RbacV1() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacV1beta1", reflect.TypeOf((*MockClientFactory)(nil).RbacV1beta1))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacV1", reflect.TypeOf((*MockClientFactory)(nil).RbacV1))
 }
 
 // StewardInformerFactory mocks base method

--- a/pkg/k8s/serviceAccountManager.go
+++ b/pkg/k8s/serviceAccountManager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/rbac/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -22,13 +22,13 @@ type ServiceAccountManager interface {
 
 type serviceAccountManager struct {
 	factory ClientFactory
-	client  corev1.ServiceAccountInterface
+	client  corev1client.ServiceAccountInterface
 }
 
 // ServiceAccountWrap wraps a Service Account and enriches it with futher things
 type ServiceAccountWrap struct {
 	factory ClientFactory
-	cache   *v1.ServiceAccount
+	cache   *corev1.ServiceAccount
 }
 
 // RoleName to be attached
@@ -47,7 +47,7 @@ func NewServiceAccountManager(factory ClientFactory, namespace string) ServiceAc
 //   pipelineCloneSecretName	(optional) the name of the secret to be used to authenticate at the Git repository hosting the pipeline definition.
 //   imagePullSecretNames		(optional) a list of image pull secrets to attach to this service account (e.g. for pulling the Jenkinsfile Runner image)
 func (c *serviceAccountManager) CreateServiceAccount(ctx context.Context, name string, pipelineCloneSecretName string, imagePullSecretNames []string) (*ServiceAccountWrap, error) {
-	serviceAccount := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	serviceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	serviceAccountWrap := &ServiceAccountWrap{
 		factory: c.factory,
 		cache:   serviceAccount,
@@ -65,7 +65,7 @@ func (c *serviceAccountManager) CreateServiceAccount(ctx context.Context, name s
 
 // GetServiceAccount gets a ServiceAccount from the cluster
 func (c *serviceAccountManager) GetServiceAccount(ctx context.Context, name string) (serviceAccount *ServiceAccountWrap, err error) {
-	var account *v1.ServiceAccount
+	var account *corev1.ServiceAccount
 	if account, err = c.client.Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return
 	}
@@ -100,7 +100,7 @@ func (a *ServiceAccountWrap) AttachSecrets(secretNames ...string) {
 			continue
 		}
 		if !haveSecretAlready(secretName) {
-			secretRef := v1.ObjectReference{Name: secretName}
+			secretRef := corev1.ObjectReference{Name: secretName}
 			secretRefs = append(secretRefs, secretRef)
 			changed = true
 		}
@@ -135,7 +135,7 @@ func (a *ServiceAccountWrap) AttachImagePullSecrets(secretNames ...string) {
 			continue
 		}
 		if !haveSecretAlready(secretName) {
-			secretRef := v1.LocalObjectReference{Name: secretName}
+			secretRef := corev1.LocalObjectReference{Name: secretName}
 			secretRefs = append(secretRefs, secretRef)
 			changed = true
 		}
@@ -169,11 +169,11 @@ func (a *ServiceAccountWrap) Update(ctx context.Context) error {
 }
 
 // AddRoleBinding creates a role binding in the targetNamespace connecting the service account with the specified cluster role
-func (a *ServiceAccountWrap) AddRoleBinding(ctx context.Context, clusterRole RoleName, targetNamespace string) (*v1beta1.RoleBinding, error) {
+func (a *ServiceAccountWrap) AddRoleBinding(ctx context.Context, clusterRole RoleName, targetNamespace string) (*rbacv1.RoleBinding, error) {
 
 	//Check if cluster role exists
 	if checkRoleExistence {
-		clusterRole, err := a.factory.RbacV1beta1().ClusterRoles().Get(ctx, string(clusterRole), metav1.GetOptions{})
+		clusterRole, err := a.factory.RbacV1().ClusterRoles().Get(ctx, string(clusterRole), metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -183,20 +183,20 @@ func (a *ServiceAccountWrap) AddRoleBinding(ctx context.Context, clusterRole Rol
 	}
 
 	//Create role binding
-	roleBindingClient := a.factory.RbacV1beta1().RoleBindings(targetNamespace)
-	roleBinding := &v1beta1.RoleBinding{
+	roleBindingClient := a.factory.RbacV1().RoleBindings(targetNamespace)
+	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(clusterRole),
 			Namespace: targetNamespace,
 		},
-		Subjects: []v1beta1.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      a.cache.GetName(),
 				Namespace: a.cache.GetNamespace(),
 			},
 		},
-		RoleRef: v1beta1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     string(clusterRole),
@@ -207,7 +207,7 @@ func (a *ServiceAccountWrap) AddRoleBinding(ctx context.Context, clusterRole Rol
 }
 
 // GetServiceAccount returns *v1.ServiceAccount
-func (a *ServiceAccountWrap) GetServiceAccount() *v1.ServiceAccount {
+func (a *ServiceAccountWrap) GetServiceAccount() *corev1.ServiceAccount {
 	return a.cache
 }
 


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
Steward used some Kubernetes API versions that are deprecated in newer Kubernetes releases.

The following replacements have been applied:

- `apiextensions.k8s.io/v1beta1` → `apiextensions.k8s.io/v1`
- `rbac.authorization.k8s.io/v1beta1` → `rbac.authorization.k8s.io/v1`


### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information
    - [x] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
