### PR TITLE
Add ignore label for pipeline runs and tenants

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,18 @@
   date: TBD
   changes:
 
+    - type: enhancement
+      impact: patch
+      title: Add ignore label
+      description: |-
+        For tests it is required to create/update Steward CROs, but avoid that
+        Steward controllers act on them.
+
+        A new label `steward.sap.com/ignore` (without value) instructs Steward
+        controllers to ignore this API object.
+        The label should never be added to an existing API object.
+      pullRequestNumber: 300
+
 - version: "0.17.0"
   date: 2021-12-13
   changes:

--- a/pkg/apis/steward/v1alpha1/constants.go
+++ b/pkg/apis/steward/v1alpha1/constants.go
@@ -35,6 +35,11 @@ const (
 	// The value of the label is ignored and should be empty.
 	LabelSystemManaged = steward.GroupName + "/system-managed"
 
+	// LabelIgnore is the key of the label whose presence indicates
+	// that this resource object should be ignored by the Steward system.
+	// The value of the label is ignored and should be empty.
+	LabelIgnore = steward.GroupName + "/ignore"
+
 	// LabelOwnerClientName is the key of the label that identifies the Steward
 	// _client_ that the labelled object is owned by.
 	// As Steward clients are currently represented by K8s namespaces only,

--- a/pkg/k8s/fake/pipelineRun.go
+++ b/pkg/k8s/fake/pipelineRun.go
@@ -1,17 +1,18 @@
 package fake
 
 import (
-	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PipelineRun creates a new pipeline run object.
-func PipelineRun(name string, namespace string, spec api.PipelineSpec) *api.PipelineRun {
-	typeMeta := metav1.TypeMeta{Kind: "PipelineRun", APIVersion: "steward.sap.com/v1alpha1"}
-	objectMeta := ObjectMeta(name, namespace)
-	return &api.PipelineRun{
-		TypeMeta:   typeMeta,
-		ObjectMeta: objectMeta,
+func PipelineRun(name string, namespace string, spec stewardv1alpha1.PipelineSpec) *stewardv1alpha1.PipelineRun {
+	return &stewardv1alpha1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: stewardv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "PipelineRun",
+		},
+		ObjectMeta: ObjectMeta(name, namespace),
 		Spec:       spec,
 	}
 }

--- a/pkg/k8s/fake/tenant.go
+++ b/pkg/k8s/fake/tenant.go
@@ -1,16 +1,17 @@
 package fake
 
 import (
-	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
+	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Tenant creates a new fake tenant object.
-func Tenant(tenantID, namespace string) *api.Tenant {
-	typeMeta := metav1.TypeMeta{Kind: "Tenant", APIVersion: "steward.sap.com/v1alpha1"}
-	objectMeta := metav1.ObjectMeta{Name: tenantID, Namespace: namespace}
-	return &api.Tenant{
-		TypeMeta:   typeMeta,
-		ObjectMeta: objectMeta,
+func Tenant(name, namespace string) *stewardv1alpha1.Tenant {
+	return &stewardv1alpha1.Tenant{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: stewardv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Tenant",
+		},
+		ObjectMeta: ObjectMeta(name, namespace),
 	}
 }

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SAP/stewardci-core/pkg/runctl/cfg"
 	"github.com/SAP/stewardci-core/pkg/runctl/metrics"
 	run "github.com/SAP/stewardci-core/pkg/runctl/run"
+	"github.com/SAP/stewardci-core/pkg/stewardlabels"
 	"github.com/SAP/stewardci-core/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -302,6 +303,10 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	// If pipelineRun is not found there is nothing to sync
 	if pipelineRunAPIObj == nil {
+		return nil
+	}
+	// don't process if labelled as to be ignored
+	if stewardlabels.IsLabelledAsIgnore(pipelineRunAPIObj) {
 		return nil
 	}
 	// fast exit - no finalizer cleanup needed

--- a/pkg/stewardlabels/labelling.go
+++ b/pkg/stewardlabels/labelling.go
@@ -20,6 +20,27 @@ func LabelAsSystemManaged(obj metav1.Object) {
 	obj.SetLabels(labels)
 }
 
+// LabelAsIgnore sets label `steward.sap.com/ignore` at
+// the given object.
+func LabelAsIgnore(obj metav1.Object) {
+	if obj == nil {
+		return
+	}
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[stewardv1alpha1.LabelIgnore] = ""
+	obj.SetLabels(labels)
+}
+
+// IsLabelledAsIgnore return whether the given resource object is labelled
+// as to be ignored by Steward.
+func IsLabelledAsIgnore(obj metav1.Object) bool {
+	_, exists := obj.GetLabels()[stewardv1alpha1.LabelIgnore]
+	return exists
+}
+
 // LabelAsOwnedByClientNamespace sets some labels on `obj` that identify it
 // as owned by the Steward client represented by the given namespace.
 // Fails if there's a conflict with existing labels, e.g. `obj` is labelled

--- a/pkg/tenantctl/controller.go
+++ b/pkg/tenantctl/controller.go
@@ -13,6 +13,7 @@ import (
 	stewardv1alpha1 "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
 	stewardv1alpha1listers "github.com/SAP/stewardci-core/pkg/client/listers/steward/v1alpha1"
 	k8s "github.com/SAP/stewardci-core/pkg/k8s"
+	"github.com/SAP/stewardci-core/pkg/stewardlabels"
 	slabels "github.com/SAP/stewardci-core/pkg/stewardlabels"
 	metrics "github.com/SAP/stewardci-core/pkg/tenantctl/metrics"
 	utils "github.com/SAP/stewardci-core/pkg/utils"
@@ -238,6 +239,11 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	if origTenant == nil {
+		return nil
+	}
+
+	// don't process if labelled as to be ignored
+	if stewardlabels.IsLabelledAsIgnore(origTenant) {
 		return nil
 	}
 


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
For tests it is required to create/update Steward CROs, but avoid that Steward controllers act on them.

A new label `steward.sap.com/ignore` (without value) instructs Steward controllers to ignore this API object. The label should never be added to an existing API object.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information
    - [x] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
