### PR TITLE
Fix metric `steward_pipelineruns_ongoing_state_duration_periodic_observations_seconds`

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,15 @@
   date: TBD
   changes:
 
+    - type: bug
+      impact: patch
+      title: Fix metric steward_pipelineruns_ongoing_state_duration_periodic_observations_seconds
+      description: |-
+        No observations were made for phases `preparing` and `waiting`.
+        For observations of phases `cleaning` and `finished` the duration
+        was including the duration of phase `running`.
+      pullRequestNumber: 322
+
 - version: "0.19.0"
   date: 2022-04-19
   changes:

--- a/pkg/runctl/metrics/pipelineruns_periodic.go
+++ b/pkg/runctl/metrics/pipelineruns_periodic.go
@@ -72,8 +72,8 @@ func (m *pipelineRunsPeriodic) init() {
 func (m *pipelineRunsPeriodic) Observe(run *stewardapi.PipelineRun) {
 	if m.isNewRun(run) {
 		m.observe(stewardapi.StateNew, run.CreationTimestamp)
-	} else if run.Status.StartedAt != nil {
-		m.observe(run.Status.State, *run.Status.StartedAt)
+	} else {
+		m.observe(run.Status.State, run.Status.StateDetails.StartedAt)
 	}
 }
 

--- a/pkg/runctl/metrics/pipelineruns_periodic_test.go
+++ b/pkg/runctl/metrics/pipelineruns_periodic_test.go
@@ -84,6 +84,7 @@ func Test_pipelineRunsPeriodic_NewRun(t *testing.T) {
 
 				run := &stewardapi.PipelineRun{}
 				run.Status.State = tc.state
+				run.Status.StateDetails.State = state
 				if !tc.omitCreationTime {
 					run.CreationTimestamp = metav1.NewTime(mockClock.Now().Add(-tc.duration))
 				}

--- a/pkg/runctl/metrics/pipelineruns_periodic_test.go
+++ b/pkg/runctl/metrics/pipelineruns_periodic_test.go
@@ -87,11 +87,8 @@ func Test_pipelineRunsPeriodic_NewRun(t *testing.T) {
 				if !tc.omitCreationTime {
 					run.CreationTimestamp = metav1.NewTime(mockClock.Now().Add(-tc.duration))
 				}
-				{
-					// Start time should be ignored. Set it to see whether it's used anyway.
-					t := metav1.NewTime(mockClock.Now().Add(24 * time.Hour))
-					run.Status.StartedAt = &t
-				}
+				// Start time should be ignored. Set it to see whether it's used anyway.
+				run.Status.StateDetails.StartedAt = metav1.NewTime(mockClock.Now().Add(-24 * time.Hour))
 
 				// EXERCISE and VERIFY
 				doTestPipelineRunsPeriodic(
@@ -163,11 +160,11 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 
 				run := &stewardapi.PipelineRun{}
 				run.Status.State = state
+				run.Status.StateDetails.State = state
 				// Creation time should be ignored. Set it to see whether it's used anyway.
 				run.CreationTimestamp = metav1.NewTime(mockClock.Now().Add(-24 * time.Hour))
 				if !tc.omitStartTime {
-					t := metav1.NewTime(mockClock.Now().Add(-tc.duration))
-					run.Status.StartedAt = &t
+					run.Status.StateDetails.StartedAt = metav1.NewTime(mockClock.Now().Add(-tc.duration))
 				}
 
 				// EXERCISE and VERIFY

--- a/pkg/runctl/metrics/pipelineruns_periodic_test.go
+++ b/pkg/runctl/metrics/pipelineruns_periodic_test.go
@@ -155,7 +155,6 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 				defer func() {
 					if t.Failed() {
 						t.Logf("tc was: %+v", tc)
-						t.Logf("state was: %#v", state)
 					}
 				}()
 
@@ -179,7 +178,7 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 					run,
 					tc.duration,
 					tc.expectObservation,
-					state,
+					tc.state,
 				)
 			})
 		}

--- a/pkg/runctl/metrics/pipelineruns_periodic_test.go
+++ b/pkg/runctl/metrics/pipelineruns_periodic_test.go
@@ -84,7 +84,7 @@ func Test_pipelineRunsPeriodic_NewRun(t *testing.T) {
 
 				run := &stewardapi.PipelineRun{}
 				run.Status.State = tc.state
-				run.Status.StateDetails.State = state
+				run.Status.StateDetails.State = tc.state
 				if !tc.omitCreationTime {
 					run.CreationTimestamp = metav1.NewTime(mockClock.Now().Add(-tc.duration))
 				}
@@ -112,6 +112,7 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 
 	for _, tc := range []struct {
 		omitStartTime     bool
+		state             stewardapi.State
 		duration          time.Duration // must be a small duration
 		expectObservation bool
 	}{
@@ -144,7 +145,10 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 			stewardapi.StateFinished,
 			stewardapi.State("testdummy5489674598"),
 		} {
+			tc := tc
+			tc.state = state
 			idx++
+
 			t.Run(strconv.Itoa(idx), func(t *testing.T) {
 				// no parallel: patching global state
 
@@ -160,8 +164,8 @@ func Test_pipelineRunsPeriodic_NonNewRun(t *testing.T) {
 				mockClock.Set(fakeNow)
 
 				run := &stewardapi.PipelineRun{}
-				run.Status.State = state
-				run.Status.StateDetails.State = state
+				run.Status.State = tc.state
+				run.Status.StateDetails.State = tc.state
 				// Creation time should be ignored. Set it to see whether it's used anyway.
 				run.CreationTimestamp = metav1.NewTime(mockClock.Now().Add(-24 * time.Hour))
 				if !tc.omitStartTime {


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
The duration of an observed pipelinerun's current phase is wrongly calculated based on the start of the pipeline run (`status.startedAt`) instead of the start of the current phase (`status.stateDetails.startedAt`).

Consequently no observations are made for phases `preparing` and `waiting`, because there was no start time yet. For observations of phases `cleaning` and `finished` the duration is too long.

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- N/A Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- N/A Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- N/A Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information
    - [x] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
