### PR TITLE
Fix start time of phase "running"

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,15 @@
   date: TBD
   changes:
 
+    - type: internal
+      impact: patch
+      title: Fix Start Time
+      description: |-
+        The start time of running phase started at tekton task run start time.
+        With this fix we now take the start time of the step executing the jenkins file runner.
+      pullRequestNumber: 0
+      jiraIssueNumber: 1974
+      
 - version: "0.24.0"
   date: 2022-12-23
   changes:

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -58,7 +58,7 @@
       description: |-
         The start time of running phase started at tekton task run start time.
         With this fix we now take the start time of the step executing the jenkins file runner.
-      pullRequestNumber: 0
+      pullRequestNumber: 350
       jiraIssueNumber: 1974
       
 - version: "0.24.0"

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -54,10 +54,15 @@
 
     - type: internal
       impact: patch
-      title: Fix Start Time
+      title: Fix start time of phase "running"
       description: |-
-        The start time of running phase started at tekton task run start time.
-        With this fix we now take the start time of the step executing the jenkins file runner.
+        The start time of phase "running" was set to the start time of the
+        Tekton TaskRun for JFR, which is when the pod has been _created_.
+        But phase "waiting" now covers the time until successful start-up
+        of the containers in the pod, which can be significantly after pod
+        creation, e.g. due to image pull time.
+        Therefore, the start time of phase "running" is now the start time
+        of the the JRF container.
       pullRequestNumber: 350
       jiraIssueNumber: 1974
       

--- a/pkg/runctl/run.go
+++ b/pkg/runctl/run.go
@@ -11,6 +11,10 @@ import (
 	knativeapis "knative.dev/pkg/apis"
 )
 
+const (
+	jfrStepName = "step-jenkinsfile-runner"
+)
+
 type tektonRun struct {
 	tektonTaskRun *tekton.TaskRun
 }
@@ -30,7 +34,12 @@ func (r *tektonRun) GetStartTime() *metav1.Time {
 	if condition.IsUnknown() && condition.Reason != tekton.TaskRunReasonRunning.String() {
 		return nil
 	}
-	return r.tektonTaskRun.Status.StartTime
+	for _, step := range r.tektonTaskRun.Status.Steps {
+		if step.ContainerName == jfrStepName && step.Running != nil {
+			return &step.Running.StartedAt
+		}
+	}
+	return nil
 }
 
 // GetCompletionTime returns completion time of run if already completed

--- a/pkg/runctl/run.go
+++ b/pkg/runctl/run.go
@@ -38,6 +38,9 @@ func (r *tektonRun) GetStartTime() *metav1.Time {
 		if step.ContainerName == jfrStepName && step.Running != nil {
 			return &step.Running.StartedAt
 		}
+		if step.ContainerName == jfrStepName && step.Terminated != nil {
+			return &step.Terminated.StartedAt
+		}
 	}
 	return nil
 }

--- a/pkg/runctl/run_test.go
+++ b/pkg/runctl/run_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	time1                     = `2019-05-14T08:24:08Z`
+	time1                     = `2019-05-14T08:24:11Z`
 	emptyBuild                = `{}`
 	startedBuild              = `{"status": {"startTime": "` + time1 + `"}}`
 	runningBuild              = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + time1 + `"}}]}}`
@@ -32,13 +32,13 @@ const (
     status: Unknown
     type: Succeeded
   podName: build-pod-38aa76
-  startTime: "` + time1 + `"
+  startTime: "2019-05-14T08:24:08Z"
   steps:
   - container: step-jenkinsfile-runner
     imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
     name: jenkinsfile-runner
     running:
-      startedAt: "2019-05-14T08:24:11Z"
+      startedAt: "` + time1 + `"
 `
 
 	realCompletedSuccess = `status:

--- a/pkg/runctl/run_test.go
+++ b/pkg/runctl/run_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	time1                     = `2019-05-14T08:24:11Z`
+	taskStartTime             = `2019-05-14T08:24:08Z`
+	stepStartTime             = `2019-05-14T08:24:11Z`
 	emptyBuild                = `{}`
-	startedBuild              = `{"status": {"startTime": "` + time1 + `"}}`
-	runningBuild              = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + time1 + `"}}]}}`
+	runningBuild              = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + stepStartTime + `"}}]}}`
 	completedSuccess          = `{"status": {"conditions": [{"message": "message1", "reason": "Succeeded", "status": "True", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Completed", "message": "ok", "exitCode": 0}}]}}`
 	completedFail             = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 1}}]}}`
 	completedValidationFailed = `{"status": {"conditions": [{"message": "message1", "reason": "TaskRunValidationFailed", "status": "False", "type": "Succeeded"}]}}`
@@ -26,19 +26,19 @@ const (
 
 	realStartedBuild = `status:
   conditions:
-  - lastTransitionTime: "2019-05-14T08:24:12Z"
+  - lastTransitionTime: ` + taskStartTime + `
     message: Not all Steps in the Task have finished executing
     reason: Running
     status: Unknown
     type: Succeeded
   podName: build-pod-38aa76
-  startTime: "2019-05-14T08:24:08Z"
+  startTime: 
   steps:
   - container: step-jenkinsfile-runner
     imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
     name: jenkinsfile-runner
     running:
-      startedAt: "` + time1 + `"
+      startedAt: "` + stepStartTime + `"
 `
 
 	realCompletedSuccess = `status:
@@ -148,7 +148,7 @@ func Test__GetStartTime_UnsetReturnsNil(t *testing.T) {
 }
 
 func Test__GetStartTime_Set(t *testing.T) {
-	expectedTime := generateTime(time1)
+	expectedTime := generateTime(stepStartTime)
 	run := NewRun(fakeTektonTaskRunYaml(realStartedBuild))
 	startTime := run.GetStartTime()
 	assert.Assert(t, expectedTime.Equal(startTime), fmt.Sprintf("Expected: %s, Is: %s", expectedTime, startTime))


### PR DESCRIPTION
### Description

The start time of phase "running" was set to the start time of the Tekton TaskRun for JFR, which is when the pod has been _created_. But phase "waiting" now covers the time until successful start-up of the containers in the pod, which can be significantly after pod creation, e.g. due to image pull time.

Therefore, the start time of phase "running" is now the start time of the the JRF container.

### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
