### PR TITLE
[CPCCICD-715] improve error code handling

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,7 +51,13 @@
 - version: NEXT
   date: TBD
   changes:
-
+ - type: internal
+      impact: minor
+      title: Use JFR image with improve error handling
+      description: |-
+        Steward can now handle different error codes provided by the improved JFR image.
+      pullRequestNumber: 0
+      jiraIssueNumber: 715
 - version: "0.24.1"
   date: 2023-01-12
   changes:

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,7 +51,7 @@
 - version: NEXT
   date: TBD
   changes:
- - type: internal
+    - type: internal
       impact: minor
       title: Use JFR image with improved error handling
       description: |-

--- a/charts/steward/Chart.yaml
+++ b/charts/steward/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.24.2-dev
+version: 0.25.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.24.2-dev
+appVersion: 0.25.0-dev

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -85,7 +85,7 @@ pipelineRuns:
     elasticsearch:
       indexURL: ""
   jenkinsfileRunner:
-    image: "stewardci/stewardci-jenkinsfile-runner:221118_24e6615"
+    image: "stewardci/stewardci-jenkinsfile-runner:TBD"
     imagePullPolicy: IfNotPresent
     javaOpts: >-
       -Dhudson.slaves.NodeProvisioner.initialDelay=0

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -85,7 +85,7 @@ pipelineRuns:
     elasticsearch:
       indexURL: ""
   jenkinsfileRunner:
-    image: "stewardci/stewardci-jenkinsfile-runner:TBD"
+    image: "stewardci/stewardci-jenkinsfile-runner:221118_24e6615"
     imagePullPolicy: IfNotPresent
     javaOpts: >-
       -Dhudson.slaves.NodeProvisioner.initialDelay=0

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -85,7 +85,7 @@ pipelineRuns:
     elasticsearch:
       indexURL: ""
   jenkinsfileRunner:
-    image: "stewardci/stewardci-jenkinsfile-runner:230125_b29a3f0"
+    image: "stewardci/stewardci-jenkinsfile-runner:230126_b29a3f0"
     imagePullPolicy: IfNotPresent
     javaOpts: >-
       -Dhudson.slaves.NodeProvisioner.initialDelay=0

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -85,7 +85,7 @@ pipelineRuns:
     elasticsearch:
       indexURL: ""
   jenkinsfileRunner:
-    image: "stewardci/stewardci-jenkinsfile-runner:221118_24e6615"
+    image: "stewardci/stewardci-jenkinsfile-runner:230125_b29a3f0"
     imagePullPolicy: IfNotPresent
     javaOpts: >-
       -Dhudson.slaves.NodeProvisioner.initialDelay=0

--- a/pkg/runctl/run_test.go
+++ b/pkg/runctl/run_test.go
@@ -14,12 +14,15 @@ import (
 )
 
 const (
-	taskStartTime             = `2019-05-14T08:24:08Z`
-	stepStartTime             = `2019-05-14T08:24:11Z`
-	emptyBuild                = `{}`
-	runningBuild              = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + stepStartTime + `"}}]}}`
-	completedSuccess          = `{"status": {"conditions": [{"message": "message1", "reason": "Succeeded", "status": "True", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Completed", "message": "ok", "exitCode": 0}}]}}`
-	completedFail             = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 1}}]}}`
+	taskStartTime         = `2019-05-14T08:24:08Z`
+	stepStartTime         = `2019-05-14T08:24:11Z`
+	emptyBuild            = `{}`
+	runningBuild          = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + stepStartTime + `"}}]}}`
+	completedSuccess      = `{"status": {"conditions": [{"message": "message1", "reason": "Succeeded", "status": "True", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Completed", "message": "ok", "exitCode": 0}}]}}`
+	completedErrorInfra   = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 1}}]}}`
+	completedErrorContent = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 2}}]}}`
+	completedErrorConfig  = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 3}}]}}`
+
 	completedValidationFailed = `{"status": {"conditions": [{"message": "message1", "reason": "TaskRunValidationFailed", "status": "False", "type": "Succeeded"}]}}`
 	//See issue https://github.com/SAP/stewardci-core/issues/? TODO: create public issue. internal: 21
 	timeout = `{"status": {"conditions": [{"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"", "reason": "TaskRunTimeout", "status": "False", "type": "Succeeded"}]}}`
@@ -171,12 +174,35 @@ func Test__IsFinished_CompletedSuccess(t *testing.T) {
 }
 
 func Test__IsFinished_CompletedFail(t *testing.T) {
-	build := fakeTektonTaskRun(completedFail)
-	run := NewRun(build)
-	finished, result := run.IsFinished()
-	assert.Assert(t, run.GetContainerInfo().Terminated != nil)
-	assert.Assert(t, finished == true)
-	assert.Equal(t, result, api.ResultErrorContent)
+	for _, test := range []struct {
+		name           string
+		trString       string
+		expectedResult api.Result
+	}{
+		{
+			name:           "infra_error",
+			trString:       completedErrorInfra,
+			expectedResult: api.ResultErrorInfra,
+		}, {
+			name:           "error_content",
+			trString:       completedErrorContent,
+			expectedResult: api.ResultErrorContent,
+		}, {
+			name:           "error_confix",
+			trString:       completedErrorConfig,
+			expectedResult: api.ResultErrorConfig,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+
+			build := fakeTektonTaskRun(test.trString)
+			run := NewRun(build)
+			finished, result := run.IsFinished()
+			assert.Assert(t, run.GetContainerInfo().Terminated != nil)
+			assert.Assert(t, finished == true)
+			assert.Equal(t, result, test.expectedResult)
+		})
+	}
 }
 
 func Test__IsFinished_CompletedValidationFail(t *testing.T) {
@@ -198,7 +224,9 @@ func Test__IsFinished_Timeout(t *testing.T) {
 func Test__IsRestartable_False(t *testing.T) {
 	for id, taskrun := range []string{
 		completedSuccess,
-		completedFail,
+		completedErrorInfra,
+		completedErrorConfig,
+		completedErrorContent,
 		completedValidationFailed,
 		timeout,
 	} {

--- a/pkg/runctl/run_test.go
+++ b/pkg/runctl/run_test.go
@@ -14,16 +14,74 @@ import (
 )
 
 const (
-	taskStartTime         = `2019-05-14T08:24:08Z`
-	stepStartTime         = `2019-05-14T08:24:11Z`
-	emptyBuild            = `{}`
-	runningBuild          = `{"status": {"steps": [{"name": "jenkinsfile-runner", "running": {"startedAt": "` + stepStartTime + `"}}]}}`
-	completedSuccess      = `{"status": {"conditions": [{"message": "message1", "reason": "Succeeded", "status": "True", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Completed", "message": "ok", "exitCode": 0}}]}}`
-	completedErrorInfra   = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 1}}]}}`
-	completedErrorContent = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 2}}]}}`
-	completedErrorConfig  = `{"status": {"conditions": [{"message": "message1", "reason": "Failed", "status": "False", "type": "Succeeded"}], "steps": [{"name": "jenkinsfile-runner", "terminated": {"reason": "Error", "message": "ko", "exitCode": 3}}]}}`
+	taskStartTime = `2019-05-14T08:24:08Z`
+	stepStartTime = `2019-05-14T08:24:11Z`
+	emptyBuild    = `{}`
 
-	completedValidationFailed = `{"status": {"conditions": [{"message": "message1", "reason": "TaskRunValidationFailed", "status": "False", "type": "Succeeded"}]}}`
+	runningBuild = `{"status":
+	                  {"steps": [
+	                    {"name": "jenkinsfile-runner",
+	                     "running": {"startedAt": "` + stepStartTime + `"}}]}}`
+
+	completedSuccess = `{"status":
+	                        {"conditions": [
+	                            {"message": "message1",
+	                             "reason": "Succeeded",
+	                             "status": "True",
+	                             "type": "Succeeded"}],
+	                         "steps": [
+	                            {"name": "jenkinsfile-runner",
+	                             "terminated": {
+	                                "reason": "Completed",
+	                                "message": "ok",
+	                                "exitCode": 0}}]}}`
+
+	completedErrorInfra = `{"status":
+	                           {"conditions": [
+	                               {"message": "message1",
+	                                "reason": "Failed",
+	                                "status": "False",
+	                                "type": "Succeeded"}],
+	                            "steps": [
+	                               {"name": "jenkinsfile-runner",
+	                                "terminated": {
+	                                   "reason": "Error",
+	                                   "message": "ko",
+	                                   "exitCode": 1}}]}}`
+
+	completedErrorContent = `{"status":
+	                            {"conditions": [
+	                                {"message": "message1",
+	                                 "reason": "Failed",
+	                                 "status": "False",
+	                                 "type": "Succeeded"}],
+	                             "steps": [
+	                                {"name": "jenkinsfile-runner",
+	                                 "terminated": {
+	                                    "reason": "Error",
+	                                    "message": "ko",
+	                                    "exitCode": 2}}]}}`
+
+	completedErrorConfig = `{"status":
+	                           {"conditions": [
+	                               {"message": "message1",
+	                                "reason": "Failed",
+	                                "status": "False",
+	                                "type": "Succeeded"}],
+	                            "steps": [
+	                               {"name": "jenkinsfile-runner",
+	                                "terminated": {
+	                                   "reason": "Error",
+	                                   "message": "ko",
+	                                   "exitCode": 3}}]}}`
+
+	completedValidationFailed = `{"status":
+	                                {"conditions": [
+	                                    {"message": "message1",
+	                                     "reason": "TaskRunValidationFailed",
+	                                     "status": "False",
+	                                     "type": "Succeeded"}]}}`
+
 	//See issue https://github.com/SAP/stewardci-core/issues/? TODO: create public issue. internal: 21
 	timeout = `{"status": {"conditions": [{"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"", "reason": "TaskRunTimeout", "status": "False", "type": "Succeeded"}]}}`
 


### PR DESCRIPTION
### Description

Steward can now distinguish error_infra, error_config and error_content depending on the RC of the jenkins file runner.

See https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/97


### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
