### PR TITLE
[CPCCICD-726] Create service account token for run namespace

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -59,6 +59,7 @@
         To avoid problems with this braking change the feature flag CreateServiceAccountTokenInRunNamespace
         is introduced with this change. Enable it when using steward on K8S 1.24+.
       pullRequestNumber: 355
+      jiraIssueNumber: 726
 
 - version: "0.25.1"
   date: 2023-01-30

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,14 @@
 - version: NEXT
   date: TBD
   changes:
+    - type: enhancement
+      impact: minor
+      title: Introduce creation of Service Account Tokens for Run Namespaces
+      description: |-
+        With K8S 1.24 or higher Service Account Tokens are not created automatically anymore.
+        To avoid problems with this braking change the feature flag CreateServiceAccountTokenInRunNamespace
+        is introduced with this change. Enable it when using steward on K8S 1.24+.
+      pullRequestNumber: 0
 
 - version: "0.25.1"
   date: 2023-01-30

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -58,7 +58,7 @@
         With K8S 1.24 or higher Service Account Tokens are not created automatically anymore.
         To avoid problems with this braking change the feature flag CreateServiceAccountTokenInRunNamespace
         is introduced with this change. Enable it when using steward on K8S 1.24+.
-      pullRequestNumber: 0
+      pullRequestNumber: 355
 
 - version: "0.25.1"
   date: 2023-01-30

--- a/charts/steward/Chart.yaml
+++ b/charts/steward/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.25.2-dev
+version: 0.26.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.25.2-dev
+appVersion: 0.26.0-dev

--- a/charts/steward/README.md
+++ b/charts/steward/README.md
@@ -223,6 +223,7 @@ The definition string has leading and trailing separators and uses different sep
 | Feature Flag | Description | Default |
 | --- | --- | --- |
 | `RetryOnInvalidPipelineRunsConfig` | If enabled, the pipeline run controller retries reconciling PipelineRun objects in case the controller configuration (in ConfigMaps) is invalid or cannot be loaded. It is assumed that the condition can be detected by a monitoring tool, triggers an alert and operators fix the issue in a timely manner. By that operator errors do not immediately break user pipeline runs. However, processing of PipelineRun objects may be delayed significantly in case of invalid configuration.<br/><br/> If disabled, the current behavior is used: immediately set all unfinished PipelineRun objects to finished with result code `error_infra`.<br/><br/>  The new behavior is supposed to become the default in a future release of Steward. | disabled |
+| `CreateServiceAccountTokenInRunNamespace` | If enabled, steward takes care for the creation of the service account token in the created run namespaces. This is required if steward runs on K8S version 1.24 or higher. | disabled |
 
 ### Misc
 

--- a/pkg/featureflag/flags.go
+++ b/pkg/featureflag/flags.go
@@ -11,4 +11,8 @@ var (
 	// RetryOnInvalidPipelineRunsConfig controls whether the execution of a pipeline run
 	// is failed or retried on pipeline run configuration errors.
 	RetryOnInvalidPipelineRunsConfig = New("RetryOnInvalidPipelineRunsConfig", Bool(false))
+
+	// CreateServiceAccountTokenInRunNamespace controls whether steward is requesting
+	// Service Account Tokens for Run Namespaces. This is required for K8S 1.24+
+	CreateServiceAccountTokenInRunNamespace = New("CreateServiceAccountTokenInRunNamespace", Bool(false))
 )

--- a/pkg/runctl/run_manager_test.go
+++ b/pkg/runctl/run_manager_test.go
@@ -255,6 +255,34 @@ func Test__runManager_prepareRunNamespace__Calls_setupStaticNetworkPolicies_AndP
 	assert.Assert(t, methodCalled == true)
 }
 
+func Test__runManager_createServiceAccountToken(t *testing.T) {
+	t.Parallel()
+
+	// SETUP
+	const (
+		serviceAccountName = "serviceAccount1"
+	)
+	h := newTestHelper1(t)
+
+	cf := newFakeClientFactory(
+		k8sfake.Namespace(h.runNamespace1),
+	)
+
+	secretProvider := secretproviderfakes.NewProvider(h.namespace1)
+
+	examinee := newRunManager(cf, secretProvider)
+	// EXERCISE
+	resultErr := examinee.createServiceAccountToken(h.ctx, serviceAccountName, h.runNamespace1)
+
+	// VERIFY
+	assert.NilError(t, resultErr)
+
+	secret, err := cf.CoreV1().Secrets(h.runNamespace1).Get(h.ctx, serviceAccountTokenName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, secret != nil)
+
+}
+
 func Test__runManager_ensureServiceAccountToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

With K8S 1.24+ the service account tokens are not created automatically anymore.
With this change a feature flag is introduced to enable steward to create service account tokens
for run namespaces on its own. 

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
