### PR TITLE
CPCCICD-1045 Enable log forwarding

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,6 +51,22 @@
 - version: NEXT
   date: TBD
   changes:
+    - type: enhancement
+      impact: minor
+      title: Enable log forwarding
+      description: |-
+        We want to add support for log-forwarders (i.e. fluentd) instead of sending logs directly to OpenSearch/ElasticSearch.
+        For this purpose, two configuration extension are prepared:
+
+        * Set environment variables to configure the elasticsearch-log-plugin to forward data to fluentd
+        * Enable the use of tekton sidecars. This can be used to run the forwarder as a sidecar container in the JFR pod
+      upgradeNotes: |-
+        The change does not affect the current behavior as long as the new configuration options are not used.
+
+        In order to use log forwarding, a version of the JFR image is required which contain this fix:
+        https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/101
+      pullRequestNumber: 379
+      jiraIssueNumber: CPCCICD-1045
 
 - version: "0.27.2"
   date: 2023-04-20

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -63,8 +63,8 @@
       upgradeNotes: |-
         The change does not affect the current behavior as long as the new configuration options are not used.
 
-        In order to use log forwarding, a version of the JFR image is required which contain this fix:
-        https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/101
+        In order to use log forwarding, a version of the JFR image later than "230426_ed390b3" is required.
+
       pullRequestNumber: 379
       jiraIssueNumber: CPCCICD-1045
 

--- a/charts/steward/Chart.yaml
+++ b/charts/steward/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.27.3-dev
+version: 0.28.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/steward/README.md
+++ b/charts/steward/README.md
@@ -162,6 +162,11 @@ Common parameters:
 | Parameter | Description | Default |
 |---|---|---|
 | <code>pipelineRuns.<wbr/><b>logging.<wbr/>elasticsearch.<wbr/>indexURL</b></code><br/><i>string</i> |  The URL of the Elasticsearch index to send logs to. If null or empty, logging to Elasticsearch is disabled. Example: `http://elasticsearch-primary.elasticsearch.svc.cluster.local:9200/jenkins-logs/_doc` | empty |
+| <code>pipelineRuns.<wbr/><b>logging.<wbr/>forwarding.<wbr/>enabled</b></code><br/><i>boolean</i> |  If "true" a forwarder will be used instead of sending logs directly to the destination. | <code>false</code> |
+| <code>pipelineRuns.<wbr/><b>logging.<wbr/>forwarding.<wbr/>host</b></code><br/><i>string</i> | The hostname of the forwarder. | empty |
+| <code>pipelineRuns.<wbr/><b>logging.<wbr/>forwarding.<wbr/>useSidecar</b></code><br/><i>boolean</i> | If "true", the fowarder is expected to run as a sidecare of the jenkinsfileRunner pod. In that case "host" will be ignored. | <code>false</code> |
+| <code>pipelineRuns.<wbr/><b>logging.<wbr/>forwarding.<wbr/>port</b></code><br/><i>string</i> | The port the forwarder is listening to. | empty |
+| <code>pipelineRuns.<wbr/><b>logging.<wbr/>forwarding.<wbr/>tag</b></code><br/><i>string</i> | The tag to use when sending data to the forwarder. | empty |
 | <code>pipelineRuns.<wbr/><b>jenkinsfileRunner.<wbr/>image.<wbr/>repository</b></code><br/><i>string</i> |  <b>Deprecated</b>: Use <code>pipelineRuns.<wbr/>jenkinsfileRunner.<wbr/>image</b></code> instead. | |
 | <code>pipelineRuns.<wbr/><b>jenkinsfileRunner.<wbr/>image.<wbr/>tag</b></code><br/><i>string</i> |  <b>Deprecated</b>: Use <code>pipelineRuns.<wbr/>jenkinsfileRunner.<wbr/>image</b></code> instead.  | |
 | <code>pipelineRuns.<wbr/><b>jenkinsfileRunner.<wbr/>image.<wbr/>pullPolicy</b></code><br/><i>string</i> |  <b>Deprecated</b>: Use <code>pipelineRuns.<wbr/>jenkinsfileRunner.<wbr/>imagePullPolicy</b></code> instead. | |
@@ -175,6 +180,8 @@ Common parameters:
 | <code>pipelineRuns.<wbr/><b>jenkinsfileRunner.<wbr/>pipelineCloneRetryIntervalSec</b></code><br/><i>string</i> |  The retry interval for cloning the pipeline repository (in seconds).  | The default value is defined in the Jenkinsfile Runner image. |
 | <code>pipelineRuns.<wbr/><b>jenkinsfileRunner.<wbr/>pipelineCloneRetryTimeoutSec</b></code><br/><i>string</i> |  The retry timeout for cloning the pipeline repository (in seconds).  | The default value is defined in the Jenkinsfile Runner image. |
 | <code>pipelineRuns.<wbr/><b>podSecurityPolicyName</b></code><br/><i>string</i> |  The name of an _existing_ pod security policy that should be used by pipeline run pods. If empty, a default pod security policy will be created. | empty |
+| <code>pipelineRuns.<wbr/><b>sidecars</b></code><br/><i>list</i> | A list of sidecar containers for the task, as specified by [Tekton documentation](https://tekton.dev/vault/pipelines-main/tasks/#specifying-sidecars). | empty |
+| <code>pipelineRuns.<wbr/><b></b></code><br/><i>string</i> |  The name of an _existing_ pod security policy that should be used by pipeline run pods. If empty, a default pod security policy will be created. | empty |
 | <code>pipelineRuns.<wbr/><b>timeout</b></code><br/><i>[duration][type-duration]</i> |  The maximum execution time of pipelines. | `60m` |
 | <code>pipelineRuns.<wbr/><b>networkPolicy</b></code><br/><i>string</i> | <b>Deprecated</b>: Use <code>pipelineRuns.<wbr/>networkPolicies</code> instead. | |
 | <code>pipelineRuns.<wbr/><b>defaultNetworkPolicyName</b></code> | The name of the network policy which is used when no network profile is selected by a pipeline run spec. | `default` if <code>pipelineRuns.<wbr/>networkPolicies</code> is not set or empty. |

--- a/charts/steward/templates/task-jenkinsfile-runner.yaml
+++ b/charts/steward/templates/task-jenkinsfile-runner.yaml
@@ -123,9 +123,28 @@ spec:
       value: '$(params.RUN_CAUSE)'
     - name: TERMINATION_LOG_PATH
       value: /tekton/results/jfr-termination-log
+    {{ with .Values.pipelineRuns.logging.forwarding }}{{ if .enabled }}
+    - name: PIPELINE_LOG_FLUENTD_HOST
+      {{ if .useSidecar }}
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+      {{ else }}
+      value: {{ required "the host name of the log-forwarder" .host  }}
+      {{ end }}
+    - name: PIPELINE_LOG_FLUENTD_PORT
+      value: {{ .port | quote }}
+    - name: PIPELINE_LOG_FLUENTD_TAG
+      value: {{ .tag }}
+    {{ end }}{{ end}}
     resources:
       {{- toYaml .Values.pipelineRuns.jenkinsfileRunner.resources | nindent 6 }}
     terminationMessagePath: /tekton/results/jfr-termination-log
   results:
   - name: jfr-termination-log
     description: The termination log message from the Jenkinsfile Runner
+  {{ with .Values.pipelineRuns.sidecars }}
+  sidecars:
+    {{ toYaml . | nindent 4 }}
+  {{ end }}
+

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -84,6 +84,18 @@ pipelineRuns:
   logging:
     elasticsearch:
       indexURL: ""
+    forwarding:
+      # If "true" a forwarder will be used instead of sending logs directly to the destination
+      enabled: false
+      # The hostname of the forwarder
+      host: ""
+      # If "true", the fowarder is expected to run as a sidecare of the jenkinsfileRunner pod.
+      # In that case "host" will be ignored.
+      useSidecar: true
+      # The port the forwarder is listening to
+      port: '24224'
+      # The tag to use when sending data to the forwarder
+      tag: BUILD_LOGS
   jenkinsfileRunner:
     image: "stewardci/stewardci-jenkinsfile-runner:230201_c535874"
     imagePullPolicy: IfNotPresent
@@ -106,6 +118,9 @@ pipelineRuns:
       fsGroup: 1000
     pipelineCloneRetryIntervalSec: ""
     pipelineCloneRetryTimeoutSec: ""
+  # defines a list of sidecars for this tasks
+  # see: https://tekton.dev/vault/pipelines-main/tasks/#specifying-sidecars
+  sidecars: []
   timeout: "60m"
   waitTimeout: "10m"
   defaultNetworkPolicyName: ""

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -85,16 +85,10 @@ pipelineRuns:
     elasticsearch:
       indexURL: ""
     forwarding:
-      # If "true" a forwarder will be used instead of sending logs directly to the destination
       enabled: false
-      # The hostname of the forwarder
       host: ""
-      # If "true", the fowarder is expected to run as a sidecare of the jenkinsfileRunner pod.
-      # In that case "host" will be ignored.
       useSidecar: true
-      # The port the forwarder is listening to
       port: '24224'
-      # The tag to use when sending data to the forwarder
       tag: BUILD_LOGS
   jenkinsfileRunner:
     image: "stewardci/stewardci-jenkinsfile-runner:230201_c535874"
@@ -118,8 +112,6 @@ pipelineRuns:
       fsGroup: 1000
     pipelineCloneRetryIntervalSec: ""
     pipelineCloneRetryTimeoutSec: ""
-  # defines a list of sidecars for this tasks
-  # see: https://tekton.dev/vault/pipelines-main/tasks/#specifying-sidecars
   sidecars: []
   timeout: "60m"
   waitTimeout: "10m"

--- a/charts/steward/values.yaml
+++ b/charts/steward/values.yaml
@@ -91,7 +91,7 @@ pipelineRuns:
       port: '24224'
       tag: BUILD_LOGS
   jenkinsfileRunner:
-    image: "stewardci/stewardci-jenkinsfile-runner:230201_c535874"
+    image: "stewardci/stewardci-jenkinsfile-runner:230426_ed390b3"
     imagePullPolicy: IfNotPresent
     javaOpts: >-
       -Dhudson.slaves.NodeProvisioner.initialDelay=0


### PR DESCRIPTION
### Description


We want to add support for log-forwarders (i.e. fluentd) instead of sending logs directly to OpenSearch/ElasticSearch. For this purpose, two configuration extension for the Helm chart are prepared:

* Set environment variables to configure the elasticsearch-log-plugin to forward data to fluentd
* Enable the use of tekton sidecars. This can be used to run the forwarder as a sidecar container in the JFR pod

Note: With the current version of the JFR image, the plugin fails at startup when configured to use fluentd. This is addressed by this fix: https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/101


### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
