### PR TITLE
Use result `error_config` instead of `error_content`

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -52,6 +52,17 @@
   date: TBD
   changes:
 
+    - type: bug
+      impact: patch
+      title: Use result 'error_config' instead of 'error_content'
+      description: |-
+        ... in case
+
+        - secrets referenced by pipeline runs don't exist
+        - multiple secrets map to the same name
+        - the configured Jenkinsfile repo server URL is invalid
+      pullRequestNumber: 416
+
 - version: "0.38.1"
   date: 2023-10-18
   changes:

--- a/pkg/runctl/secretmgr/secret_manager.go
+++ b/pkg/runctl/secretmgr/secret_manager.go
@@ -67,7 +67,7 @@ func (s SecretManager) copyPipelineCloneSecretToRunNamespace(ctx context.Context
 	}
 	repoServerURL, err := pipelineRun.GetValidatedJenkinsfileRepoServerURL()
 	if err != nil {
-		return "", serrors.Classify(err, v1alpha1.ResultErrorContent)
+		return "", serrors.Classify(err, v1alpha1.ResultErrorConfig)
 	}
 	transformers := []secrets.SecretTransformer{
 		secrets.StripAnnotationsTransformer(annotationPrefixJenkins),
@@ -97,7 +97,7 @@ func (s SecretManager) copySecrets(ctx context.Context, pipelineRun k8s.Pipeline
 	if err != nil {
 		logger.Error(err, "Could not copy secrets", "secrets", secretNames)
 		if s.secretHelper.IsNotFound(err) || k8serrors.IsInvalid(err) || k8serrors.IsAlreadyExists(err) {
-			err = serrors.Classify(err, v1alpha1.ResultErrorContent)
+			err = serrors.Classify(err, v1alpha1.ResultErrorConfig)
 		} else {
 			err = serrors.Classify(err, v1alpha1.ResultErrorInfra)
 		}

--- a/pkg/runctl/secretmgr/secret_manager_test.go
+++ b/pkg/runctl/secretmgr/secret_manager_test.go
@@ -104,7 +104,7 @@ func Test_copyPipelineCloneSecretToRunNamespace_Success(t *testing.T) {
 	examinee.copyPipelineCloneSecretToRunNamespace(th.ctx, mockPipelineRun)
 }
 
-func Test_copyPipelineCloneSecretToRunNamespace_FailsWithContentErrorOnGetPipelineRepoServerURLError(t *testing.T) {
+func Test_copyPipelineCloneSecretToRunNamespace_FailsWithConfigErrorOnGetPipelineRepoServerURLError(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
@@ -119,7 +119,7 @@ func Test_copyPipelineCloneSecretToRunNamespace_FailsWithContentErrorOnGetPipeli
 	_, err := examinee.copyPipelineCloneSecretToRunNamespace(th.ctx, mockPipelineRun)
 	assert.Assert(t, err != nil)
 	assert.Equal(t, "err1", err.Error())
-	assert.Equal(t, stewardv1alpha1.ResultErrorContent, serrors.GetClass(err))
+	assert.Equal(t, stewardv1alpha1.ResultErrorConfig, serrors.GetClass(err))
 }
 
 func Test_copyPipelineSecretsToRunNamespace(t *testing.T) {
@@ -140,7 +140,7 @@ func Test_copyPipelineSecretsToRunNamespace(t *testing.T) {
 
 }
 
-func Test_copySecrets_FailsWithContentErrorOnNotFound(t *testing.T) {
+func Test_copySecrets_FailsWithConfigErrorOnNotFound(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
@@ -161,7 +161,7 @@ func Test_copySecrets_FailsWithContentErrorOnNotFound(t *testing.T) {
 	// VERIFY
 	assert.Assert(t, err != nil)
 	assert.Equal(t, "err1", err.Error())
-	assert.Equal(t, stewardv1alpha1.ResultErrorContent, serrors.GetClass(err))
+	assert.Equal(t, stewardv1alpha1.ResultErrorConfig, serrors.GetClass(err))
 }
 
 func Test_copySecrets_FailsWithInfraErrorOnOtherError(t *testing.T) {


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->

In the following cases the preparation of a pipeline run fails with result `error_content`, although it should be `error_config`:

- secrets referenced by pipeline runs don't exist
- multiple secrets map to the same name
- the configured Jenkinsfile repo server URL is invalid


### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
