### PR TITLE
Improve handling of failed JFR TaskRuns

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -85,6 +85,25 @@
 
     - type: bug
       impact: patch
+      title: Recreate JFR TaskRun if pod creation failed
+      description: |-
+        The creation of the JFR pod may temporarily fail, e.g. due
+        to a timeout calling a mandatory admission webhook.
+        Steward now detects this and recreates the Tekton taskrun
+        to retry.
+      pullRequestNumber: 424
+
+    - type: bug
+      impact: patch
+      title: Stop waiting for finished non-restartable JFR TaskRun
+      description: |-
+        If a JFR TaskRun was never started, is finished and is not
+        restartable, Steward now fails the PipelineRun instead of
+        waiting until timeout.
+      pullRequestNumber: 424
+
+    - type: bug
+      impact: patch
       title: Fix error detected by checkmarx tool
       description: |-
         Remove redundant error from logFinalState function

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/davecgh/go-spew v1.1.1
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.3.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -685,7 +685,6 @@ github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -351,8 +351,8 @@ func (r *pipelineRun) UpdateContainer(ctx context.Context, newContainerState *co
 // StoreErrorAsMessage implements part of interface `PipelineRun`.
 func (r *pipelineRun) StoreErrorAsMessage(ctx context.Context, err error, prefix string) error {
 	if err != nil {
-		text := fmt.Sprintf("ERROR: %s [%s]: %s", utils.Trim(prefix), r.String(), err.Error())
-		r.UpdateMessage(text)
+		msg := fmt.Sprintf("ERROR: %s: %s", utils.Trim(prefix), err.Error())
+		r.UpdateMessage(msg)
 	}
 	return nil
 }

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -162,7 +162,7 @@ func Test_pipelineRun_StoreErrorAsMessage(t *testing.T) {
 	client := factory.StewardV1alpha1().PipelineRuns(ns1)
 	run, err = client.Get(ctx, "foo", metav1.GetOptions{})
 	assert.NilError(t, err)
-	assert.Equal(t, "ERROR: message1 [PipelineRun{name: foo, namespace: namespace1, state: running}]: error1", run.Status.Message)
+	assert.Equal(t, "ERROR: message1: error1", run.Status.Message)
 }
 
 func Test_pipelineRun_HasDeletionTimestamp_false(t *testing.T) {

--- a/pkg/runctl/constants/constants.go
+++ b/pkg/runctl/constants/constants.go
@@ -5,14 +5,7 @@ import (
 )
 
 const (
-
-	// RunClusterRoleName is the name of the cluster role
+	// RunClusterRoleName is the name of the cluster role that
+	// pipeline run service accounts are bound to.
 	RunClusterRoleName k8s.RoleName = "steward-run"
-
-	// JFRStepName is the name of the jfs step
-	JFRStepName = "step-jenkinsfile-runner"
-
-	// TektonTaskRunName is the name of the Tekton TaskRun in each
-	// run namespace.
-	TektonTaskRunName = "steward-jenkinsfile-runner"
 )

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -3,6 +3,7 @@ package runctl
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,7 +24,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	assert "gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ import (
 	_ "knative.dev/pkg/system/testing"
 )
 
-func Test_meterAllPipelineRunsPeriodic(t *testing.T) {
+func Test_Controller_meterAllPipelineRunsPeriodic(t *testing.T) {
 	// no parallel: patching global state
 
 	// SETUP
@@ -55,8 +56,8 @@ func Test_meterAllPipelineRunsPeriodic(t *testing.T) {
 		ControllerOpts{},
 	)
 
-	run := fake.PipelineRun("r1", "ns1", api.PipelineSpec{})
-	c.pipelineRunStore.Add(run)
+	pipelineRun := fake.PipelineRun("r1", "ns1", api.PipelineSpec{})
+	c.pipelineRunStore.Add(pipelineRun)
 
 	deletedRun := fake.PipelineRun("r2", "ns1", api.PipelineSpec{})
 	now := metav1.Now()
@@ -64,7 +65,7 @@ func Test_meterAllPipelineRunsPeriodic(t *testing.T) {
 	c.pipelineRunStore.Add(deletedRun)
 
 	// VERIFY
-	mockMetric.EXPECT().Observe(run).Times(1)
+	mockMetric.EXPECT().Observe(pipelineRun).Times(1)
 
 	// EXERCISE
 	c.meterAllPipelineRunsPeriodic()
@@ -183,13 +184,14 @@ func Test_Controller_Deletion(t *testing.T) {
 	assert.Equal(t, 0, len(run.GetFinalizers()))
 }
 
-func Test_Controller_syncHandler_givesUp_onPipelineRunNotFound(t *testing.T) {
+func Test_Controller_syncHandler_PipelineRunNotFound(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
-	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+
+	ctx := context.Background()
 
 	cf := newFakeClientFactory()
 	mockPipelineRunFetcher := mocks.NewMockPipelineRunFetcher(mockCtrl)
@@ -214,6 +216,7 @@ func Test_Controller_syncHandler_givesUp_onPipelineRunNotFound(t *testing.T) {
 
 func newController(t *testing.T, runs ...*api.PipelineRun) (*Controller, *fake.ClientFactory) {
 	t.Helper()
+
 	ctx := context.Background()
 	cf := newFakeClientFactory(runctltesting.FakeClusterRole())
 	client := cf.StewardV1alpha1()
@@ -238,89 +241,108 @@ func getAPIPipelineRun(cf *fake.ClientFactory, name, namespace string) (*api.Pip
 	return cs.StewardV1alpha1().PipelineRuns(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
-func Test_Controller_syncHandler_delete(t *testing.T) {
+func Test_Controller_syncHandler_deleted_unfinished(t *testing.T) {
 	for _, currentState := range []api.State{
+		api.StateUndefined,
 		api.StateNew,
 		api.StateWaiting,
 		api.StatePreparing,
 		api.StateRunning,
 		api.StateCleaning,
-		api.StateUndefined,
 	} {
-
-		expectedStateOnError := currentState
-
 		for _, test := range []struct {
 			name                  string
 			runManagerExpectation func(*runmocks.MockManager)
-			hasFinalizer          bool
-			expectedError         bool
-			expectedFinalizer     bool
-			expectedResult        api.Result
+			withFinalizer         bool
+			expectError           bool
+			expectFinalizer       bool
 			expectedState         api.State
+			expectedResult        api.Result
 		}{
-
-			{name: "delete with finalizer ok",
+			{
+				name: "with_finalizer/cleanup_succeeds",
 				runManagerExpectation: func(rm *runmocks.MockManager) {
-					rm.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(nil)
 				},
-				hasFinalizer:      true,
-				expectedError:     false,
-				expectedFinalizer: false,
-				expectedResult:    api.ResultDeleted,
-				expectedState:     api.StateFinished,
+				withFinalizer:   true,
+				expectError:     false,
+				expectFinalizer: false,
+				expectedState:   api.StateFinished,
+				expectedResult:  api.ResultDeleted,
 			},
-			{name: "delete with finalizer fail",
+			{
+				name: "with_finalizer/cleanup_fails",
 				runManagerExpectation: func(rm *runmocks.MockManager) {
-					rm.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(fmt.Errorf("expected"))
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(errors.New("expected"))
 				},
-				hasFinalizer:      true,
-				expectedError:     true,
-				expectedFinalizer: true,
-				expectedResult:    api.ResultUndefined,
-				expectedState:     expectedStateOnError,
+				withFinalizer:   true,
+				expectError:     true,
+				expectFinalizer: true,
+				expectedState:   currentState,
+				expectedResult:  api.ResultUndefined,
 			},
-			{name: "delete without finalizer ensure finished state",
+			{
+				name: "no_finalizer/cleanup_succeeds",
 				runManagerExpectation: func(rm *runmocks.MockManager) {
-					rm.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(nil)
 				},
-				hasFinalizer:      false,
-				expectedError:     false,
-				expectedFinalizer: false,
-				expectedResult:    api.ResultDeleted,
-				expectedState:     api.StateFinished,
+				withFinalizer:   false,
+				expectError:     false,
+				expectFinalizer: false,
+				expectedState:   api.StateFinished,
+				expectedResult:  api.ResultDeleted,
+			},
+			{
+				name: "no_finalizer/cleanup_fails",
+				runManagerExpectation: func(rm *runmocks.MockManager) {
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(errors.New("expected"))
+				},
+				withFinalizer:   false,
+				expectError:     true,
+				expectFinalizer: false,
+				expectedState:   currentState,
+				expectedResult:  api.ResultUndefined,
 			},
 		} {
-			t.Run(fmt.Sprintf("%s current state %s", test.name, currentState), func(t *testing.T) {
-				currentState := currentState
-				test := test
-				t.Parallel()
-
+			t.Run(fmt.Sprintf("state_%s/%s", currentState, test.name), func(t *testing.T) {
 				// SETUP
-				run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
-				if test.hasFinalizer {
-					run.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
-				}
-				run.Status.State = currentState
-				now := metav1.Now()
-				run.SetDeletionTimestamp(&now)
-				controller, cf := newController(t, run)
 				mockCtrl := gomock.NewController(t)
 				defer mockCtrl.Finish()
+
+				pipelineRun := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
+				now := metav1.Now()
+				pipelineRun.SetDeletionTimestamp(&now)
+				pipelineRun.Status.State = currentState
+
+				if test.withFinalizer {
+					pipelineRun.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
+				}
+
+				controller, cf := newController(t, pipelineRun)
 				runManager := runmocks.NewMockManager(mockCtrl)
 				test.runManagerExpectation(runManager)
+
 				controller.testing = &controllerTesting{
-					createRunManagerStub:       runManager,
+					createRunManagerStub:       newSimpleCreateRunManagerStub(runManager),
 					loadPipelineRunsConfigStub: newEmptyRunsConfig,
 				}
+
 				// EXERCISE
-				err := controller.syncHandler("ns1/foo")
+				resultErr := controller.syncHandler("ns1/foo")
 
 				// VERIFY
-				if test.expectedError {
-					assert.Assert(t, err != nil)
+				if test.expectError {
+					assert.Assert(t, resultErr != nil)
 				} else {
-					assert.NilError(t, err)
+					assert.NilError(t, resultErr)
 				}
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
@@ -328,8 +350,8 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 
 				assert.Equal(t, test.expectedResult, result.Status.Result)
 				assert.Equal(t, test.expectedState, result.Status.State)
-				if test.expectedFinalizer {
-					assert.Assert(t, len(result.GetFinalizers()) == 1)
+				if test.expectFinalizer {
+					assert.Assert(t, cmp.Contains(result.GetFinalizers(), k8s.FinalizerName))
 				} else {
 					assert.Assert(t, len(result.GetFinalizers()) == 0)
 				}
@@ -338,42 +360,53 @@ func Test_Controller_syncHandler_delete(t *testing.T) {
 	}
 }
 
-func Test_Controller_syncHandler_delete_on_finished_keeps_result_unchanged(t *testing.T) {
-	for _, currentResult := range []api.Result{
-		api.ResultDeleted,
-		api.ResultSuccess,
-		api.ResultErrorContent,
-		api.ResultAborted,
-		api.ResultErrorConfig,
-		api.ResultErrorInfra} {
-		for _, hasFinalizer := range []bool{true, false} {
-			t.Run(fmt.Sprintf("finalizer %t current result %s", hasFinalizer, currentResult), func(t *testing.T) {
-				currentResult := currentResult
-				hasFinalizer := hasFinalizer
-				t.Parallel()
+func Test_Controller_syncHandler_deleted_finished(t *testing.T) {
+	t.Parallel()
 
+	for _, currentResult := range []api.Result{
+		api.ResultSuccess,
+		api.ResultErrorConfig,
+		api.ResultErrorContent,
+		api.ResultErrorInfra,
+		api.ResultAborted,
+		api.ResultDeleted,
+	} {
+		for _, withFinalizer := range []bool{true, false} {
+			var namePartFinalizer string
+			if withFinalizer {
+				namePartFinalizer = "with_finalizer"
+			} else {
+				namePartFinalizer = "no_finalizer"
+			}
+
+			t.Run(fmt.Sprintf("result_%s/%s", currentResult, namePartFinalizer), func(t *testing.T) {
 				// SETUP
-				run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
-				if hasFinalizer {
-					run.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
-				}
-				run.Status.State = api.StateFinished
-				run.Status.Result = currentResult
-				now := metav1.Now()
-				run.SetDeletionTimestamp(&now)
-				controller, cf := newController(t, run)
 				mockCtrl := gomock.NewController(t)
 				defer mockCtrl.Finish()
+
+				pipelineRun := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
+				now := metav1.Now()
+				pipelineRun.SetDeletionTimestamp(&now)
+				pipelineRun.Status.State = api.StateFinished
+				pipelineRun.Status.Result = currentResult
+
+				if withFinalizer {
+					pipelineRun.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
+				}
+
+				controller, cf := newController(t, pipelineRun)
 				runManager := runmocks.NewMockManager(mockCtrl)
+
 				controller.testing = &controllerTesting{
-					createRunManagerStub:       runManager,
+					createRunManagerStub:       newSimpleCreateRunManagerStub(runManager),
 					loadPipelineRunsConfigStub: newEmptyRunsConfig,
 				}
+
 				// EXERCISE
-				err := controller.syncHandler("ns1/foo")
+				resultErr := controller.syncHandler("ns1/foo")
 
 				// VERIFY
-				assert.NilError(t, err)
+				assert.NilError(t, resultErr)
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
 				t.Logf("Pipeline run result: status: %+v", result.Status)
@@ -386,110 +419,116 @@ func Test_Controller_syncHandler_delete_on_finished_keeps_result_unchanged(t *te
 	}
 }
 
-func Test_Controller_syncHandler_mock_start(t *testing.T) {
-	error1 := fmt.Errorf("error1")
-	errorRecover1 := serrors.Recoverable(error1)
+func Test_Controller_syncHandler_new(t *testing.T) {
+	error1 := errors.New("error1")
+	errorRecoverable1 := serrors.Recoverable(errors.New("errorRecoverable1"))
 
-	for _, currentStatus := range []api.PipelineStatus{
-		{},
-		{
-			State: api.StateNew,
-		},
+	for _, currentState := range []api.State{
+		api.StateUndefined,
+		api.StateNew,
 	} {
 		for _, test := range []struct {
-			name                   string
-			pipelineSpec           api.PipelineSpec
-			runManagerExpectation  func(*runmocks.MockManager, *runmocks.MockRun)
-			pipelineRunsConfigStub func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error)
-			isMaintenanceModeStub  func(ctx context.Context) (bool, error)
-			expectedResult         api.Result
-			expectedState          api.State
-			expectedMessage        string
-			expectedError          error
+			name                       string
+			pipelineRunSpec            api.PipelineSpec
+			runManagerExpectation      func(*runmocks.MockManager, *runmocks.MockRun)
+			loadPipelineRunsConfigStub func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error)
+			isMaintenanceModeStub      func(ctx context.Context) (bool, error)
+			expectedError              error
+			expectedState              api.State
+			expectedResult             api.Result
 		}{
 			{
-				name:         "new_ok",
-				pipelineSpec: api.PipelineSpec{},
+				name:            "prepare_succeeds",
+				pipelineRunSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any()).Return("", "", nil)
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", nil)
 				},
-				pipelineRunsConfigStub: newEmptyRunsConfig,
-				isMaintenanceModeStub:  newIsMaintenanceModeStub(false, nil),
-				expectedResult:         api.ResultUndefined,
-				expectedState:          api.StateWaiting,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:                   "new_maintenance_error_a",
-				pipelineSpec:           api.PipelineSpec{},
-				runManagerExpectation:  func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
-				pipelineRunsConfigStub: newEmptyRunsConfig,
-				isMaintenanceModeStub:  newIsMaintenanceModeStub(false, error1),
-				expectedResult:         api.ResultUndefined,
-				expectedState:          api.StateNew,
-				expectedError:          error1,
-			},
-			{
-				name:                   "new_maintenance_error_b",
-				pipelineSpec:           api.PipelineSpec{},
-				runManagerExpectation:  func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
-				pipelineRunsConfigStub: newEmptyRunsConfig,
-				isMaintenanceModeStub:  newIsMaintenanceModeStub(true, error1),
-				expectedResult:         api.ResultUndefined,
-				expectedState:          api.StateNew,
-				expectedError:          error1,
-			},
-			{
-				name:         "new_maintenance",
-				pipelineSpec: api.PipelineSpec{},
+				name:            "prepare_fails",
+				pipelineRunSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", error1)
 				},
-				pipelineRunsConfigStub: newEmptyRunsConfig,
-				isMaintenanceModeStub:  newIsMaintenanceModeStub(true, nil),
-				expectedResult:         api.ResultUndefined,
-				expectedState:          api.StateNew,
-				expectedError:          fmt.Errorf("pipeline execution is paused while the system is in maintenance mode"),
+				expectedError:  error1,
+				expectedState:  api.StatePreparing,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:                  "new_get_cofig_fail_not_recoverable",
-				pipelineSpec:          api.PipelineSpec{},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {},
-				pipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
+				name:                  "maintenance_mode_check_fails",
+				pipelineRunSpec:       api.PipelineSpec{},
+				isMaintenanceModeStub: newIsMaintenanceModeStub(false, error1),
+				expectedError:         error1,
+				expectedState:         currentState,
+				expectedResult:        api.ResultUndefined,
+			},
+			{
+				name:                  "maintenance_mode_check_fails_but_returns_true",
+				pipelineRunSpec:       api.PipelineSpec{},
+				isMaintenanceModeStub: newIsMaintenanceModeStub(true, error1),
+				expectedError:         error1,
+				expectedState:         currentState,
+				expectedResult:        api.ResultUndefined,
+			},
+			{
+				name:                  "maintenance_mode",
+				pipelineRunSpec:       api.PipelineSpec{},
+				isMaintenanceModeStub: newIsMaintenanceModeStub(true, nil),
+				expectedError:         errors.New("pipeline execution is paused while the system is in maintenance mode"),
+				expectedState:         currentState,
+				expectedResult:        api.ResultUndefined,
+			},
+			{
+				name:            "get_pipelineruns_config_fails/unrecoverable",
+				pipelineRunSpec: api.PipelineSpec{},
+				loadPipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
 					return nil, error1
 				},
-				isMaintenanceModeStub: newIsMaintenanceModeStub(false, nil),
-				expectedResult:        api.ResultErrorInfra,
-				expectedState:         api.StateFinished,
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultErrorInfra,
 			},
 			{
-				name:         "new_get_cofig_fail_recoverable",
-				pipelineSpec: api.PipelineSpec{},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+				name:            "get_pipelineruns_config_fails/recoverable",
+				pipelineRunSpec: api.PipelineSpec{},
+				loadPipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
+					return nil, errorRecoverable1
 				},
-				pipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
-					return nil, errorRecover1
-				},
-				isMaintenanceModeStub: newIsMaintenanceModeStub(false, nil),
-				expectedResult:        api.ResultUndefined,
-				expectedState:         api.StatePreparing,
-				expectedError:         errorRecover1,
+				expectedError:  errorRecoverable1,
+				expectedState:  api.StatePreparing,
+				expectedResult: api.ResultUndefined,
 			},
 		} {
 			t.Run(test.name, func(t *testing.T) {
-				test := test
-				t.Parallel()
-
 				// SETUP
-				run := fake.PipelineRun("foo", "ns1", test.pipelineSpec)
-				run.Status = currentStatus
-				controller, cf := newController(t, run)
 				mockCtrl := gomock.NewController(t)
 				defer mockCtrl.Finish()
+
+				pipelineRun := fake.PipelineRun("foo", "ns1", test.pipelineRunSpec)
+				pipelineRun.Status.State = currentState
+
+				controller, cf := newController(t, pipelineRun)
 				runManager := runmocks.NewMockManager(mockCtrl)
 				runmock := runmocks.NewMockRun(mockCtrl)
-				test.runManagerExpectation(runManager, runmock)
+
+				if test.runManagerExpectation != nil {
+					test.runManagerExpectation(runManager, runmock)
+				}
+				if test.loadPipelineRunsConfigStub == nil {
+					test.loadPipelineRunsConfigStub = newEmptyRunsConfig
+				}
+				if test.isMaintenanceModeStub == nil {
+					test.isMaintenanceModeStub = newIsMaintenanceModeStub(false, nil)
+				}
+
 				controller.testing = &controllerTesting{
-					createRunManagerStub:       runManager,
-					loadPipelineRunsConfigStub: test.pipelineRunsConfigStub,
+					createRunManagerStub:       newSimpleCreateRunManagerStub(runManager),
+					loadPipelineRunsConfigStub: test.loadPipelineRunsConfigStub,
 					isMaintenanceModeStub:      test.isMaintenanceModeStub,
 				}
 
@@ -505,466 +544,823 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
-				t.Logf("%+v", result.Status)
-				assert.Equal(t, test.expectedResult, result.Status.Result, test.name)
-				assert.Equal(t, test.expectedState, result.Status.State, test.name)
 
-				if test.expectedMessage != "" {
-					assert.Assert(t, is.Regexp(test.expectedMessage, result.Status.Message))
-				}
+				t.Logf("Pipeline run result: status: %+v", result.Status)
+				assert.Equal(t, test.expectedResult, result.Status.Result)
+				assert.Equal(t, test.expectedState, result.Status.State)
 
 				if test.expectedState == api.StateFinished {
 					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 0)
 				} else {
-					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 1)
+					assert.Assert(t, cmp.Contains(result.GetFinalizers(), k8s.FinalizerName))
 				}
 			})
 		}
 	}
 }
 
-func Test_Controller_syncHandler_mock(t *testing.T) {
-	error1 := fmt.Errorf("error1")
-	errorRecover1 := serrors.Recoverable(error1)
+func Test_Controller_syncHandler_unfinished(t *testing.T) {
+	error1 := errors.New("error1")
+	errorRecoverable1 := serrors.Recoverable(errors.New("errorRecoverable1"))
 	longAgo := metav1.Unix(10, 10)
 
 	for _, maintenanceMode := range []bool{true, false} {
 
 		for _, test := range []struct {
 			name                       string
-			pipelineSpec               api.PipelineSpec
-			currentStatus              api.PipelineStatus
+			pipelineRunSpec            api.PipelineSpec
+			pipelineRunStatus          api.PipelineStatus
 			startedAt                  metav1.Time
 			runManagerExpectation      func(*runmocks.MockManager, *runmocks.MockRun)
 			loadPipelineRunsConfigStub func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error)
-			expectedResult             api.Result
-			expectedState              api.State
-			expectedMessage            string
 			expectedError              error
+			expectedState              api.State
+			expectedResult             api.Result
+			expectedMessage            string
 		}{
+			//----------------
+			// preparing
+			//----------------
 			{
-				name:         "preparing_ok",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "preparing/success",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any()).Return("", "", nil)
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultUndefined,
-				expectedState:              api.StateWaiting,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "preparing_fail",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "preparing/prepare_fails/error_unclassified",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any()).Return("", "", error1)
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", error1)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultUndefined,
-				expectedState:              api.StatePreparing,
-				expectedMessage:            "",
-				expectedError:              error1,
+				expectedError:  error1,
+				expectedState:  api.StatePreparing,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name: "preparing_fail_on_content_error_during_start",
-				pipelineSpec: api.PipelineSpec{
+				name: "preparing/prepare_fails/error_config",
+
+				pipelineRunSpec: api.PipelineSpec{
 					Secrets: []string{"secret1"},
 				},
-				currentStatus: api.PipelineStatus{
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StatePreparing,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", serrors.Classify(error1, api.ResultErrorContent))
+				},
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorContent,
+				expectedMessage: "preparing failed: error1",
+			},
+			{
+				name: "preparing/prepare_fails/error_content",
 
-					rm.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any()).Return("", "", serrors.Classify(error1, api.ResultErrorContent))
+				pipelineRunSpec: api.PipelineSpec{
+					Secrets: []string{"secret1"},
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultErrorContent,
-				expectedState:              api.StateCleaning,
-				expectedMessage:            "preparing failed .*error1",
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StatePreparing,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", serrors.Classify(error1, api.ResultErrorContent))
+				},
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorContent,
+				expectedMessage: "preparing failed: error1",
 			},
 			{
-				name:         "waiting_fail",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "preparing/prepare_fails/error_infra",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StatePreparing,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						Prepare(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return("", "", serrors.Classify(error1, api.ResultErrorInfra))
+				},
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: "preparing failed: error1",
+			},
+			//----------------
+			// waiting
+			//----------------
+			{
+				name: "waiting/taskrun_get_fails/unrecoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, error1)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, error1)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultErrorInfra,
-				expectedState:              api.StateCleaning,
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: "waiting failed: error1",
 			},
 			{
-				name:         "waiting_recover",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/taskrun_get_fails/recoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, errorRecover1)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, errorRecoverable1)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultUndefined,
-				expectedState:              api.StateWaiting,
-				expectedError:              errorRecover1,
+				expectedError:  errorRecoverable1,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "waiting_start_success",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/taskrun_deletion_pending/time_left",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, nil)
-					rm.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+
+					run.EXPECT().
+						IsDeleted().
+						Return(true).
+						AnyTimes()
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateWaiting,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "waiting_start_fail",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateWaiting,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, nil)
-					rm.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(error1)
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultUndefined,
-				expectedState:              api.StateWaiting,
-				expectedError:              error1,
-			},
-			{
-				name:         "waiting_fail_on_load_pipeline_run_config",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateWaiting,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, nil)
-				},
-				loadPipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
-					return nil, error1
-				},
-				expectedResult: api.ResultErrorInfra,
-				expectedState:  api.StateCleaning,
-			},
-			{
-				name:         "waiting_start_fail_on_config_error_during_start",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateWaiting,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, nil)
-					rm.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(serrors.Classify(error1, api.ResultErrorConfig))
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultErrorConfig,
-				expectedState:              api.StateCleaning,
-			},
-			{
-				name:         "waiting_not_started",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateWaiting,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().GetStartTime().Return(nil)
-					run.EXPECT().IsRestartable().Return(false)
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateWaiting,
-			},
-			{
-				name:         "waiting_started",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateWaiting,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					now := metav1.Now()
-					run.EXPECT().GetStartTime().Return(&now)
-					run.EXPECT().IsRestartable().Return(false)
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateRunning,
-			},
-			{
-				name:         "waiting_timeout",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/taskrun_deletion_pending/timeout",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				startedAt: longAgo,
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultErrorInfra,
-				expectedState:              api.StateCleaning,
-				expectedMessage:            `ERROR: waiting failed \[PipelineRun{name: foo, namespace: ns1, state: waiting}\]: main pod has not started after 10m0s`,
-			},
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
 
+					run.EXPECT().
+						IsDeleted().
+						Return(true).
+						AnyTimes()
+				},
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultErrorInfra,
+			},
 			{
-				name:         "waiting_restartable",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/get_pipelineruns_config_fails/unrecoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().IsRestartable().Return(true)
-
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
-					rm.EXPECT().DeleteRun(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateWaiting,
+				loadPipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
+					return nil, error1
+				},
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultErrorInfra,
 			},
 			{
-				name:         "waiting_restartable_delete_fails",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/get_pipelineruns_config_fails/recoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateWaiting,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().IsRestartable().Return(true)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
+				},
+				loadPipelineRunsConfigStub: func(ctx context.Context) (*cfg.PipelineRunsConfigStruct, error) {
+					return nil, errorRecoverable1
+				},
+				expectedError:  errorRecoverable1,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_start_succeeds",
 
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
-					rm.EXPECT().DeleteRun(gomock.Any(), gomock.Any()).Return(error1)
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultErrorInfra,
-				expectedState:              api.StateCleaning,
-				expectedMessage:            "restart failed",
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
+					rm.EXPECT().
+						Start(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil)
+				},
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "running_not_finished",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "waiting/taskrun_start_fails/unclassified",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
+					rm.EXPECT().
+						Start(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(error1)
+				},
+				expectedError:  error1,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_start_fails/classified",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
+					rm.EXPECT().
+						Start(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(serrors.Classify(error1, api.ResultErrorConfig))
+				},
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultErrorConfig,
+			},
+			{
+				name: "waiting/taskrun_neither_started_nor_finished/time_left",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						Return(false, api.ResultUndefined).
+						AnyTimes()
+				},
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_neither_started_nor_finished/timeout",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				startedAt: longAgo,
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						MinTimes(1)
+				},
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: `ERROR: waiting failed: main pod has not started after [0-9]+m[0-9]+s`,
+			},
+			{
+				name: "waiting/taskrun_started_but_not_finished",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					now := metav1.Now()
+					run.EXPECT().
+						GetStartTime().
+						Return(&now).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						Return(false, api.ResultUndefined).
+						AnyTimes()
+				},
+				expectedState:  api.StateRunning,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_started_and_finished",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					now := metav1.Now()
+					run.EXPECT().
+						GetStartTime().
+						Return(&now).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						Return(true, api.ResultSuccess).
+						AnyTimes()
+				},
+				expectedState:  api.StateRunning,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_not_started_but_finished/restartable/delete_succeeds",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						AnyTimes().
+						Return(true, api.ResultErrorInfra)
+					run.EXPECT().
+						IsRestartable().
+						Return(true)
+
+					rm.EXPECT().
+						DeleteRun(gomock.Any(), gomock.Any()).
+						Return(nil)
+				},
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_not_started_but_finished/restartable/delete_fails/recoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						AnyTimes().
+						Return(true, api.ResultErrorInfra)
+					run.EXPECT().
+						IsRestartable().
+						Return(true)
+
+					rm.EXPECT().
+						DeleteRun(gomock.Any(), gomock.Any()).
+						Return(errorRecoverable1)
+				},
+				expectedError:  errorRecoverable1,
+				expectedState:  api.StateWaiting,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name: "waiting/taskrun_not_started_but_finished/restartable/delete_fails/unrecoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						AnyTimes().
+						Return(true, api.ResultErrorInfra)
+					run.EXPECT().
+						IsRestartable().
+						Return(true)
+
+					rm.EXPECT().
+						DeleteRun(gomock.Any(), gomock.Any()).
+						Return(error1)
+				},
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: "waiting failed: could not restart stuck task run",
+			},
+			{
+				name: "waiting/taskrun_not_started_but_finished/not_restartable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateWaiting,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+
+					run.EXPECT().
+						IsDeleted().
+						Return(false).
+						AnyTimes()
+					run.EXPECT().
+						GetStartTime().
+						Return(nil).
+						AnyTimes()
+					run.EXPECT().
+						IsFinished().
+						AnyTimes().
+						Return(true, api.ResultErrorInfra)
+					run.EXPECT().
+						IsRestartable().
+						Return(false)
+				},
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultErrorInfra,
+			},
+			//----------------
+			// running
+			//----------------
+			{
+				name: "running/taskrun_unfinished",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().GetContainerInfo().Return(nil)
-					run.EXPECT().IsFinished().Return(false, api.ResultUndefined)
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
+					run.EXPECT().
+						GetContainerInfo().
+						Return(nil)
+					run.EXPECT().
+						IsFinished().
+						Return(false, api.ResultUndefined)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateRunning,
+				expectedState:  api.StateRunning,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "running_recover",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "running/get_taskrun_fails/recoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, errorRecover1)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, errorRecoverable1)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateRunning,
-				expectedError:              errorRecover1,
+				expectedError:  errorRecoverable1,
+				expectedState:  api.StateRunning,
+				expectedResult: api.ResultUndefined,
 			},
 			{
-				name:         "running_get_error",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "running/get_taskrun_fails/unrecoverable",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, error1)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, error1)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "error_infra",
-				expectedState:              api.StateCleaning,
-				expectedMessage:            "running failed .*error1",
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: "running failed: error1",
 			},
 			{
-				name:         "running_get_not_found",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "running/taskrun_not_found",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(nil, nil)
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(nil, nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "error_infra",
-				expectedState:              api.StateCleaning,
-				expectedMessage:            "running failed .* task run not found in namespace.*",
+				expectedState:   api.StateCleaning,
+				expectedResult:  api.ResultErrorInfra,
+				expectedMessage: "running failed: task run not found in namespace .*",
 			},
 			{
-				name:         "running_finished_timeout",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name: "running/taskrun_finished/timeout",
+
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().GetContainerInfo().Return(
-						&corev1.ContainerState{
+					run.EXPECT().
+						GetContainerInfo().
+						Return(&corev1.ContainerState{
 							Running: &corev1.ContainerStateRunning{},
 						})
 					now := metav1.Now()
-					run.EXPECT().GetCompletionTime().Return(&now)
-					run.EXPECT().IsFinished().Return(true, api.ResultTimeout)
-					run.EXPECT().GetMessage()
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
+					run.EXPECT().
+						GetCompletionTime().
+						Return(&now)
+					run.EXPECT().
+						IsFinished().
+						Return(true, api.ResultTimeout)
+					run.EXPECT().
+						GetMessage()
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultTimeout,
-				expectedState:              api.StateCleaning,
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultTimeout,
 			},
 			{
-				name:         "running_finished_terminated",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
+				name:            "running/finished_terminated",
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					run.EXPECT().GetContainerInfo().Return(
-						&corev1.ContainerState{
+					run.EXPECT().
+						GetContainerInfo().
+						Return(&corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{
 								Message: "message",
 							},
 						})
 					now := metav1.Now()
-					run.EXPECT().IsFinished().Return(true, api.ResultSuccess)
-					run.EXPECT().GetCompletionTime().Return(&now)
-					run.EXPECT().GetMessage()
-					rm.EXPECT().GetRun(gomock.Any(), gomock.Any()).Return(run, nil)
+					run.EXPECT().
+						IsFinished().
+						Return(true, api.ResultSuccess)
+					run.EXPECT().
+						GetCompletionTime().
+						Return(&now)
+					run.EXPECT().
+						GetMessage()
+					rm.EXPECT().
+						GetRun(gomock.Any(), gomock.Any()).
+						Return(run, nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultSuccess,
-				expectedState:              api.StateCleaning,
+				expectedState:  api.StateCleaning,
+				expectedResult: api.ResultSuccess,
 			},
 			{
-				name:         "skip_finished",
-				pipelineSpec: api.PipelineSpec{},
-				currentStatus: api.PipelineStatus{
-					State: api.StateFinished,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             "",
-				expectedState:              api.StateFinished,
-			},
-			{
-				name: "cleanup_abborted_new",
-				pipelineSpec: api.PipelineSpec{
+				name: "running/aborted_running",
+				pipelineRunSpec: api.PipelineSpec{
 					Intent: api.IntentAbort,
 				},
-				currentStatus: api.PipelineStatus{
-					State: api.StateUndefined,
-				},
-				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(nil)
-				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultAborted,
-				expectedState:              api.StateFinished,
-			},
-			{
-				name: "cleanup_abborted_running",
-				pipelineSpec: api.PipelineSpec{
-					Intent: api.IntentAbort,
-				},
-				currentStatus: api.PipelineStatus{
+				pipelineRunStatus: api.PipelineStatus{
 					State: api.StateRunning,
 				},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
-					rm.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(nil)
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(nil)
 				},
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:             api.ResultAborted,
-				expectedState:              api.StateFinished,
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultAborted,
+			},
+			//----------------
+			// cleaning
+			//----------------
+			// TODO add tests for state cleaning
+			//----------------
+			// finished
+			//----------------
+			{
+				name:            "finished/result_undefined",
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State:  api.StateFinished,
+					Result: api.ResultUndefined,
+				},
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultUndefined,
+			},
+			{
+				name:            "finished/result_success",
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State:  api.StateFinished,
+					Result: api.ResultSuccess,
+				},
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultSuccess,
+			},
+			{
+				name:            "finished/result_error_infra",
+				pipelineRunSpec: api.PipelineSpec{},
+				pipelineRunStatus: api.PipelineStatus{
+					State:  api.StateFinished,
+					Result: api.ResultErrorInfra,
+				},
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultErrorInfra,
+			},
+			//----------------
+			// TODO
+			//----------------
+			{
+				// TODO move into separate top-level test for abort
+				name: "new/aborted",
+				pipelineRunSpec: api.PipelineSpec{
+					Intent: api.IntentAbort,
+				},
+				pipelineRunStatus: api.PipelineStatus{
+					State: api.StateUndefined,
+				},
+				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().
+						Cleanup(gomock.Any(), gomock.Any()).
+						Return(nil)
+				},
+				expectedState:  api.StateFinished,
+				expectedResult: api.ResultAborted,
 			},
 		} {
-			t.Run(fmt.Sprintf("%+s_maintenanceMode_%t", test.name, maintenanceMode), func(t *testing.T) {
-				test := test
-				t.Parallel()
-
+			t.Run(fmt.Sprintf("%s/maintenance_mode_%t", test.name, maintenanceMode), func(t *testing.T) {
 				// SETUP
-				run := fake.PipelineRun("foo", "ns1", test.pipelineSpec)
-				run.Status = test.currentStatus
+				mockCtrl := gomock.NewController(t)
+				defer mockCtrl.Finish()
+
+				pipelineRun := fake.PipelineRun("foo", "ns1", test.pipelineRunSpec)
+				pipelineRun.Status = test.pipelineRunStatus
 				if test.startedAt.IsZero() {
 					test.startedAt = metav1.Now()
 				}
-				run.Status.StateDetails = api.StateItem{
+				pipelineRun.Status.StateDetails = api.StateItem{
 					StartedAt: test.startedAt,
 				}
-				controller, cf := newController(t, run)
-				mockCtrl := gomock.NewController(t)
-				defer mockCtrl.Finish()
+
+				controller, cf := newController(t, pipelineRun)
 				runManager := runmocks.NewMockManager(mockCtrl)
 				runmock := runmocks.NewMockRun(mockCtrl)
-				test.runManagerExpectation(runManager, runmock)
+
+				if test.runManagerExpectation != nil {
+					test.runManagerExpectation(runManager, runmock)
+				}
+				if test.loadPipelineRunsConfigStub == nil {
+					test.loadPipelineRunsConfigStub = newEmptyRunsConfig
+				}
+
 				controller.testing = &controllerTesting{
-					createRunManagerStub:       runManager,
+					createRunManagerStub:       newSimpleCreateRunManagerStub(runManager),
 					loadPipelineRunsConfigStub: test.loadPipelineRunsConfigStub,
 					isMaintenanceModeStub:      newIsMaintenanceModeStub(maintenanceMode, nil),
 				}
 
 				// EXERCISE
-				err := controller.syncHandler("ns1/foo")
+				resultErr := controller.syncHandler("ns1/foo")
 
 				// VERIFY
 				if test.expectedError != nil {
-					assert.Equal(t, test.expectedError, err)
+					assert.Error(t, resultErr, test.expectedError.Error())
 				} else {
-					assert.NilError(t, err)
+					assert.NilError(t, resultErr)
 				}
 
 				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
-				t.Logf("%+v", result.Status)
-				assert.Equal(t, test.expectedResult, result.Status.Result, test.name)
-				assert.Equal(t, test.expectedState, result.Status.State, test.name)
+
+				t.Logf("Pipeline run result: status: %+v", result.Status)
+				assert.Equal(t, test.expectedResult, result.Status.Result)
+				assert.Equal(t, test.expectedState, result.Status.State)
 
 				if test.expectedMessage != "" {
-					assert.Assert(t, is.Regexp(test.expectedMessage, result.Status.Message))
+					assert.Assert(t, cmp.Regexp(test.expectedMessage, result.Status.Message))
 				}
 
 				if test.expectedState == api.StateFinished {
 					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 0)
 				} else {
-					assert.Assert(t, len(result.ObjectMeta.Finalizers) == 1)
+					assert.Assert(t, cmp.Contains(result.GetFinalizers(), k8s.FinalizerName))
 				}
 			})
 		}
 	}
 }
 
-func Test_Controller_syncHandler_initiatesRetrying_on500DuringPipelineRunFetch(t *testing.T) {
+func Test_Controller_syncHandler_PipelineRunFetchFails_InternalServerError(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
-	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	ctx := context.Background()
+
 	cf := newFakeClientFactory()
+
 	mockPipelineRunFetcher := mocks.NewMockPipelineRunFetcher(mockCtrl)
-	message := "k8s kapot!"
+	message := "internal server error 1"
 	mockPipelineRunFetcher.EXPECT().
 		ByKey(ctx, gomock.Any()).
-		Return(nil, k8serrors.NewInternalError(fmt.Errorf(message)))
+		Return(nil, k8serrors.NewInternalError(errors.New(message)))
 
 	examinee := NewController(
 		ktesting.NewLogger(t, ktesting.DefaultConfig),
@@ -1042,6 +1438,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 				"completionTime": "2019-09-16T12:55:40Z"
 			}
 		}`),
+
 		runctltesting.FakeClusterRole(),
 	)
 
@@ -1050,6 +1447,7 @@ func Test_Controller_syncHandler_OnTimeout(t *testing.T) {
 	defer stopController(t, stopCh)
 
 	// VERIFY
+	// TODO avoid race condition with controller
 	run := getPipelineRun(t, "run1", "content-ns-1", cf)
 	status := run.GetStatus()
 
@@ -1174,6 +1572,11 @@ func newFakeClientFactory(objects ...runtime.Object) *fake.ClientFactory {
 	return cf
 }
 
+func newSimpleCreateRunManagerStub(runManager run.Manager) func(k8s.PipelineRun) run.Manager {
+	return func(k8s.PipelineRun) run.Manager {
+		return runManager
+	}
+}
 func newIsMaintenanceModeStub(maintenanceMode bool, err error) func(ctx context.Context) (bool, error) {
 	return func(ctx context.Context) (bool, error) {
 		return maintenanceMode, err

--- a/pkg/runctl/run/interfaces.go
+++ b/pkg/runctl/run/interfaces.go
@@ -12,25 +12,61 @@ import (
 
 // Manager manages runs
 type Manager interface {
-	Prepare(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (string, string, error)
-	Start(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) error
+	// CreateEnv creates a new isolated environment for a new run.
+	// If an environment exists already, it will be removed first.
+	CreateEnv(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (string, string, error)
+
+	// CreateRun creates a new run in the prepared environment.
+	// Especially fails if the environment does not exist or a run exists
+	// already.
+	CreateRun(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) error
+
+	// GetRun returns the run or nil if a run has not been created yet.
 	GetRun(ctx context.Context, pipelineRun k8s.PipelineRun) (Run, error)
-	Cleanup(ctx context.Context, pipelineRun k8s.PipelineRun) error
+
+	// DeleteRun deletes a task run for a given pipeline run.
 	DeleteRun(ctx context.Context, pipelineRun k8s.PipelineRun) error
+
+	// DeleteEnv removes an existing environment.
+	// If no environment exists, it succeeds.
+	DeleteEnv(ctx context.Context, pipelineRun k8s.PipelineRun) error
 }
 
 // Run represents a pipeline run
 type Run interface {
+	// GetStartTime returns the timestamp when the run actually started.
+	// Initialization steps should be excluded as far as possible.
+	// Returns nil if the run has not been started yet.
 	GetStartTime() *metav1.Time
-	IsRestartable() bool
-	IsFinished() (bool, steward.Result)
+
+	// GetCompletionTime returns the timestamp of the run's completion.
+	// Teardown steps should be excluded as far as possible.
+	// Returns nil if the run has never been started or has not completed yet.
 	GetCompletionTime() *metav1.Time
+
+	// IsFinished returns true if the run is finished.
+	// Note that a run can be finished without having been started, i.e.
+	// there was an error.
+	IsFinished() (bool, steward.Result)
+
+	// IsRestartable returns true if run finished unsuccessfully and can be
+	// restarted with a possibly successful result.
+	IsRestartable() bool
+
+	// GetContainerInfo returns the state of the Jenkinsfile Runner container
+	// as reported in the Tekton TaskRun status.
 	GetContainerInfo() *corev1.ContainerState
+
+	// GetMessage returns the status message.
 	GetMessage() string
+
+	// IsDeleted returns true if the receiver is nil or is marked as deleted.
 	IsDeleted() bool
 }
 
 // SecretManager manages secrets of a pipelinerun
 type SecretManager interface {
+	// CopyAll copies all the required secrets of a pipeline run to the
+	// respective run namespace.
 	CopyAll(ctx context.Context, pipelineRun k8s.PipelineRun) (string, []string, error)
 }

--- a/pkg/runctl/run/interfaces.go
+++ b/pkg/runctl/run/interfaces.go
@@ -27,6 +27,7 @@ type Run interface {
 	GetCompletionTime() *metav1.Time
 	GetContainerInfo() *corev1.ContainerState
 	GetMessage() string
+	IsDeleted() bool
 }
 
 // SecretManager manages secrets of a pipelinerun

--- a/pkg/runctl/run/mocks/mocks.go
+++ b/pkg/runctl/run/mocks/mocks.go
@@ -185,18 +185,48 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// Cleanup mocks base method.
-func (m *MockManager) Cleanup(arg0 context.Context, arg1 k8s.PipelineRun) error {
+// CreateEnv mocks base method.
+func (m *MockManager) CreateEnv(arg0 context.Context, arg1 k8s.PipelineRun, arg2 *cfg.PipelineRunsConfigStruct) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cleanup", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateEnv", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateEnv indicates an expected call of CreateEnv.
+func (mr *MockManagerMockRecorder) CreateEnv(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnv", reflect.TypeOf((*MockManager)(nil).CreateEnv), arg0, arg1, arg2)
+}
+
+// CreateRun mocks base method.
+func (m *MockManager) CreateRun(arg0 context.Context, arg1 k8s.PipelineRun, arg2 *cfg.PipelineRunsConfigStruct) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRun", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Cleanup indicates an expected call of Cleanup.
-func (mr *MockManagerMockRecorder) Cleanup(arg0, arg1 interface{}) *gomock.Call {
+// CreateRun indicates an expected call of CreateRun.
+func (mr *MockManagerMockRecorder) CreateRun(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockManager)(nil).Cleanup), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*MockManager)(nil).CreateRun), arg0, arg1, arg2)
+}
+
+// DeleteEnv mocks base method.
+func (m *MockManager) DeleteEnv(arg0 context.Context, arg1 k8s.PipelineRun) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEnv", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEnv indicates an expected call of DeleteEnv.
+func (mr *MockManagerMockRecorder) DeleteEnv(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnv", reflect.TypeOf((*MockManager)(nil).DeleteEnv), arg0, arg1)
 }
 
 // DeleteRun mocks base method.
@@ -226,36 +256,6 @@ func (m *MockManager) GetRun(arg0 context.Context, arg1 k8s.PipelineRun) (run.Ru
 func (mr *MockManagerMockRecorder) GetRun(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRun", reflect.TypeOf((*MockManager)(nil).GetRun), arg0, arg1)
-}
-
-// Prepare mocks base method.
-func (m *MockManager) Prepare(arg0 context.Context, arg1 k8s.PipelineRun, arg2 *cfg.PipelineRunsConfigStruct) (string, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prepare", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// Prepare indicates an expected call of Prepare.
-func (mr *MockManagerMockRecorder) Prepare(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockManager)(nil).Prepare), arg0, arg1, arg2)
-}
-
-// Start mocks base method.
-func (m *MockManager) Start(arg0 context.Context, arg1 k8s.PipelineRun, arg2 *cfg.PipelineRunsConfigStruct) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockManagerMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), arg0, arg1, arg2)
 }
 
 // MockSecretManager is a mock of SecretManager interface.

--- a/pkg/runctl/run/mocks/mocks.go
+++ b/pkg/runctl/run/mocks/mocks.go
@@ -119,6 +119,20 @@ func (mr *MockRunMockRecorder) GetStartTime() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStartTime", reflect.TypeOf((*MockRun)(nil).GetStartTime))
 }
 
+// IsDeleted mocks base method.
+func (m *MockRun) IsDeleted() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDeleted")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDeleted indicates an expected call of IsDeleted.
+func (mr *MockRunMockRecorder) IsDeleted() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDeleted", reflect.TypeOf((*MockRun)(nil).IsDeleted))
+}
+
 // IsFinished mocks base method.
 func (m *MockRun) IsFinished() (bool, v1alpha1.Result) {
 	m.ctrl.T.Helper()

--- a/pkg/runctl/runmgr/constants.go
+++ b/pkg/runctl/runmgr/constants.go
@@ -1,3 +1,27 @@
 package runmgr
 
-const jfrResultKey string = "jfr-termination-log"
+import steward "github.com/SAP/stewardci-core/pkg/apis/steward"
+
+const (
+	// JFRTaskRunName is the name of the Tekton TaskRun in each
+	// run namespace.
+	JFRTaskRunName = "steward-jenkinsfile-runner"
+
+	// JFRTaskRunStepName is the name of the step in the Tekton TaskRun that executes
+	// the Jenkinsfile Runner
+	JFRTaskRunStepName = "jenkinsfile-runner"
+)
+
+const (
+	runNamespacePrefix       = "steward-run"
+	runNamespaceRandomLength = 5
+	serviceAccountName       = "default"
+	serviceAccountTokenName  = "steward-serviceaccount-token"
+
+	// in general, the token of the above service account should not be automatically mounted into pods
+	automountServiceAccountToken = false
+
+	annotationPipelineRunKey = steward.GroupName + "/pipeline-run-key"
+
+	jfrResultKey string = "jfr-termination-log"
+)

--- a/pkg/runctl/runmgr/helpers_for_test.go
+++ b/pkg/runctl/runmgr/helpers_for_test.go
@@ -14,7 +14,6 @@ import (
 	k8smocks "github.com/SAP/stewardci-core/pkg/k8s/mocks"
 	secretmocks "github.com/SAP/stewardci-core/pkg/k8s/secrets/mocks"
 	cfg "github.com/SAP/stewardci-core/pkg/runctl/cfg"
-	"github.com/SAP/stewardci-core/pkg/runctl/constants"
 	runctltesting "github.com/SAP/stewardci-core/pkg/runctl/testing"
 	tektonfakeclient "github.com/SAP/stewardci-core/pkg/tektonclient/clientset/versioned/fake"
 	gomock "github.com/golang/mock/gomock"
@@ -152,7 +151,7 @@ func (h *testHelper1) dummyTektonTaskRun() *tektonv1beta1.TaskRun {
 	t.Helper()
 	return &tektonv1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.TektonTaskRunName,
+			Name:      JFRTaskRunName,
 			Namespace: h.runNamespace1,
 		},
 	}

--- a/pkg/runctl/runmgr/run.go
+++ b/pkg/runctl/runmgr/run.go
@@ -2,8 +2,7 @@ package runmgr
 
 import (
 	steward "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
-	"github.com/SAP/stewardci-core/pkg/runctl/constants"
-	run "github.com/SAP/stewardci-core/pkg/runctl/run"
+	runifc "github.com/SAP/stewardci-core/pkg/runctl/run"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	termination "github.com/tektoncd/pipeline/pkg/termination"
 	"go.uber.org/zap"
@@ -17,37 +16,40 @@ const (
 	jfrExitCodeErrorConfig  = 3
 )
 
+// tektonRun is a runifc.Run based on Tekton.
 type tektonRun struct {
 	tektonTaskRun *tekton.TaskRun
 }
 
-// NewRun returns new Run
-func NewRun(tektonTaskRun *tekton.TaskRun) run.Run {
+// Compiler check for interface compliance
+var _ runifc.Run = (*tektonRun)(nil)
+
+// newRun creates a new tektonRun
+func newRun(tektonTaskRun *tekton.TaskRun) *tektonRun {
 	return &tektonRun{tektonTaskRun: tektonTaskRun}
 }
 
-// GetStartTime returns start time of run if already started
-// start time must not be returned if condition is unknown but not running
+// GetStartTime implements runifc.Run.
 func (r *tektonRun) GetStartTime() *metav1.Time {
 	condition := r.getSucceededCondition()
 	if condition == nil {
 		return nil
 	}
-	if condition.IsUnknown() && condition.Reason != tekton.TaskRunReasonRunning.String() {
+	if condition.IsUnknown() && condition.Reason != string(tekton.TaskRunReasonRunning) {
 		return nil
 	}
-	for _, step := range r.tektonTaskRun.Status.Steps {
-		if step.ContainerName == constants.JFRStepName && step.Running != nil {
-			return &step.Running.StartedAt
+	if stepState := r.getJFRStepState(); stepState != nil {
+		if stepState.Running != nil {
+			return &stepState.Running.StartedAt
 		}
-		if step.ContainerName == constants.JFRStepName && step.Terminated != nil {
-			return &step.Terminated.StartedAt
+		if stepState.Terminated != nil {
+			return &stepState.Terminated.StartedAt
 		}
 	}
 	return nil
 }
 
-// GetCompletionTime returns completion time of run if already completed
+// GetCompletionTime implements runifc.Run.
 func (r *tektonRun) GetCompletionTime() *metav1.Time {
 	completionTime := r.tektonTaskRun.Status.CompletionTime
 	if completionTime != nil {
@@ -65,10 +67,9 @@ func (r *tektonRun) GetCompletionTime() *metav1.Time {
 	return &now
 }
 
-// GetContainerInfo returns the state of the Jenkinsfile Runner container
-// as reported in the Tekton TaskRun status.
+// GetContainerInfo implements runifc.Run.
 func (r *tektonRun) GetContainerInfo() *corev1.ContainerState {
-	stepState := r.getJenkinsfileRunnerStepState()
+	stepState := r.getJFRStepState()
 	if stepState == nil {
 		return nil
 	}
@@ -79,7 +80,7 @@ func (r *tektonRun) getSucceededCondition() *knativeapis.Condition {
 	return r.tektonTaskRun.Status.GetCondition(knativeapis.ConditionSucceeded)
 }
 
-// IsRestartable returns true if run is finished but could be restarted
+// IsRestartable implements runifc.Run.
 func (r *tektonRun) IsRestartable() bool {
 	condition := r.getSucceededCondition()
 	if condition.IsFalse() {
@@ -94,7 +95,7 @@ func (r *tektonRun) IsRestartable() bool {
 	return false
 }
 
-// IsFinished returns true if run is finished
+// IsFinished implements runifc.Run.
 func (r *tektonRun) IsFinished() (bool, steward.Result) {
 	condition := r.getSucceededCondition()
 	if condition.IsUnknown() {
@@ -108,7 +109,7 @@ func (r *tektonRun) IsFinished() (bool, steward.Result) {
 	case string(tekton.TaskRunReasonTimedOut):
 		return true, steward.ResultTimeout
 	case string(tekton.TaskRunReasonFailed):
-		jfrStepState := r.getJenkinsfileRunnerStepState()
+		jfrStepState := r.getJFRStepState()
 		if jfrStepState != nil && jfrStepState.Terminated != nil {
 			switch jfrStepState.Terminated.ExitCode {
 			case jfrExitCodeErrorContent:
@@ -123,7 +124,7 @@ func (r *tektonRun) IsFinished() (bool, steward.Result) {
 	return true, steward.ResultErrorInfra
 }
 
-// GetMessage returns the termination message
+// GetMessage implements runifc.Run.
 func (r *tektonRun) GetMessage() string {
 	var msg string
 
@@ -150,14 +151,15 @@ func (r *tektonRun) GetMessage() string {
 	return "internal error"
 }
 
+// IsDeleted implements runifc.Run.
 func (r *tektonRun) IsDeleted() bool {
 	return r == nil || r.tektonTaskRun.DeletionTimestamp != nil
 }
 
-func (r *tektonRun) getJenkinsfileRunnerStepState() *tekton.StepState {
+func (r *tektonRun) getJFRStepState() *tekton.StepState {
 	steps := r.tektonTaskRun.Status.Steps
 	for _, stepState := range steps {
-		if stepState.Name == tektonTaskJenkinsfileRunnerStep {
+		if stepState.Name == JFRTaskRunStepName {
 			return &stepState
 		}
 	}

--- a/pkg/runctl/runmgr/run_manager.go
+++ b/pkg/runctl/runmgr/run_manager.go
@@ -694,11 +694,11 @@ func (c *runManager) GetRun(ctx context.Context, pipelineRun k8s.PipelineRun) (r
 	return NewRun(run), nil
 }
 
-// DeleteRun deletes a tekton run based on a pipelineRun
+// DeleteRun deletes a JFR task run for a given pipeline run.
 func (c *runManager) DeleteRun(ctx context.Context, pipelineRun k8s.PipelineRun) error {
 	namespace := pipelineRun.GetRunNamespace()
 	if namespace == "" {
-		return fmt.Errorf("cannot delete taskrun, runnamespace not set in %q", pipelineRun.GetName())
+		return fmt.Errorf("cannot delete taskrun, run namespace not set in %q", pipelineRun.GetName())
 	}
 	err := c.factory.TektonV1beta1().TaskRuns(namespace).Delete(ctx, constants.TektonTaskRunName, metav1.DeleteOptions{})
 

--- a/pkg/runctl/runmgr/run_manager.go
+++ b/pkg/runctl/runmgr/run_manager.go
@@ -33,30 +33,18 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-const (
-	runNamespacePrefix       = "steward-run"
-	runNamespaceRandomLength = 5
-	serviceAccountName       = "default"
-	serviceAccountTokenName  = "steward-serviceaccount-token"
-
-	// in general, the token of the above service account should not be automatically mounted into pods
-	automountServiceAccountToken = false
-
-	// tektonTaskJenkinsfileRunnerStep is the name of the step
-	// in the Tekton TaskRun that executes the Jenkinsfile Runner
-	tektonTaskJenkinsfileRunnerStep = "jenkinsfile-runner"
-
-	annotationPipelineRunKey = steward.GroupName + "/pipeline-run-key"
-)
-
-type runManager struct {
+// TektonRunManager is an implementation of runifc.Manager based on Tekton.
+type TektonRunManager struct {
 	factory        k8s.ClientFactory
 	secretProvider secrets.SecretProvider
 
-	testing *runManagerTesting
+	testing *tektonRunManagerTesting
 }
 
-type runManagerTesting struct {
+// Compiler check for interface compliance
+var _ runifc.Manager = (*TektonRunManager)(nil)
+
+type tektonRunManagerTesting struct {
 	cleanupStub                               func(context.Context, *runContext) error
 	copySecretsToRunNamespaceStub             func(context.Context, *runContext) (string, []string, error)
 	createTektonTaskRunStub                   func(context.Context, *runContext) error
@@ -80,16 +68,16 @@ type runContext struct {
 	serviceAccount     *k8s.ServiceAccountWrap
 }
 
-// NewRunManager creates a new runManager.
-func NewRunManager(factory k8s.ClientFactory, secretProvider secrets.SecretProvider) runifc.Manager {
-	return &runManager{
+// NewTektonRunManager creates a new TektonRunManager.
+func NewTektonRunManager(factory k8s.ClientFactory, secretProvider secrets.SecretProvider) *TektonRunManager {
+	return &TektonRunManager{
 		factory:        factory,
 		secretProvider: secretProvider,
 	}
 }
 
-// Prepare prepares the isolated environment for a new run
-func (c *runManager) Prepare(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (namespace string, auxNamespace string, err error) {
+// CreateEnv implements runifc.Manager.
+func (c *TektonRunManager) CreateEnv(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (namespace string, auxNamespace string, err error) {
 
 	runCtx := &runContext{
 		pipelineRun:        pipelineRun,
@@ -117,8 +105,8 @@ func (c *runManager) Prepare(ctx context.Context, pipelineRun k8s.PipelineRun, p
 	return runCtx.runNamespace, runCtx.auxNamespace, nil
 }
 
-// Start starts the run in the environment prepared by Prepare.
-func (c *runManager) Start(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (err error) {
+// CreateRun implements runifc.Manager.
+func (c *TektonRunManager) CreateRun(ctx context.Context, pipelineRun k8s.PipelineRun, pipelineRunsConfig *cfg.PipelineRunsConfigStruct) (err error) {
 
 	runCtx := &runContext{
 		pipelineRun:        pipelineRun,
@@ -132,7 +120,7 @@ func (c *runManager) Start(ctx context.Context, pipelineRun k8s.PipelineRun, pip
 
 // prepareRunNamespace creates a new namespace for the pipeline run
 // and populates it with needed resources.
-func (c *runManager) prepareRunNamespace(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) prepareRunNamespace(ctx context.Context, runCtx *runContext) error {
 
 	if c.testing != nil && c.testing.prepareRunNamespaceStub != nil {
 		return c.testing.prepareRunNamespaceStub(ctx, runCtx)
@@ -182,7 +170,7 @@ func (c *runManager) prepareRunNamespace(ctx context.Context, runCtx *runContext
 	return nil
 }
 
-func (c *runManager) setupServiceAccount(ctx context.Context, runCtx *runContext, pipelineCloneSecretName string, imagePullSecrets []string) error {
+func (c *TektonRunManager) setupServiceAccount(ctx context.Context, runCtx *runContext, pipelineCloneSecretName string, imagePullSecrets []string) error {
 	if c.testing != nil && c.testing.setupServiceAccountStub != nil {
 		return c.testing.setupServiceAccountStub(ctx, runCtx, pipelineCloneSecretName, imagePullSecrets)
 	}
@@ -214,7 +202,7 @@ func (c *runManager) setupServiceAccount(ctx context.Context, runCtx *runContext
 	return nil
 }
 
-func (c *runManager) attachAllSecrets(ctx context.Context, runCtx *runContext, accountManager k8s.ServiceAccountManager, pipelineCloneSecretName string, imagePullSecrets []string) (*k8s.ServiceAccountWrap, error) {
+func (c *TektonRunManager) attachAllSecrets(ctx context.Context, runCtx *runContext, accountManager k8s.ServiceAccountManager, pipelineCloneSecretName string, imagePullSecrets []string) (*k8s.ServiceAccountWrap, error) {
 	logger := klog.FromContext(ctx)
 
 	var serviceAccount *k8s.ServiceAccountWrap
@@ -247,14 +235,14 @@ func (c *runManager) attachAllSecrets(ctx context.Context, runCtx *runContext, a
 	return serviceAccount, nil
 }
 
-func (c *runManager) copySecretsToRunNamespace(ctx context.Context, runCtx *runContext) (string, []string, error) {
+func (c *TektonRunManager) copySecretsToRunNamespace(ctx context.Context, runCtx *runContext) (string, []string, error) {
 	if c.testing != nil && c.testing.copySecretsToRunNamespaceStub != nil {
 		return c.testing.copySecretsToRunNamespaceStub(ctx, runCtx)
 	}
 	return c.getSecretManager(runCtx).CopyAll(ctx, runCtx.pipelineRun)
 }
 
-func (c *runManager) getSecretManager(runCtx *runContext) runifc.SecretManager {
+func (c *TektonRunManager) getSecretManager(runCtx *runContext) runifc.SecretManager {
 	if c.testing != nil && c.testing.getSecretManagerStub != nil {
 		return c.testing.getSecretManagerStub(runCtx)
 	}
@@ -263,7 +251,7 @@ func (c *runManager) getSecretManager(runCtx *runContext) runifc.SecretManager {
 	return secretmgr.NewSecretManager(secretHelper)
 }
 
-func (c *runManager) setupStaticNetworkPolicies(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupStaticNetworkPolicies(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupStaticNetworkPoliciesStub != nil {
 		return c.testing.setupStaticNetworkPoliciesStub(ctx, runCtx)
 	}
@@ -283,7 +271,7 @@ func (c *runManager) setupStaticNetworkPolicies(ctx context.Context, runCtx *run
 	return nil
 }
 
-func (c *runManager) setupNetworkPolicyThatIsolatesAllPods(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupNetworkPolicyThatIsolatesAllPods(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupNetworkPolicyThatIsolatesAllPodsStub != nil {
 		return c.testing.setupNetworkPolicyThatIsolatesAllPodsStub(ctx, runCtx)
 	}
@@ -312,7 +300,7 @@ func (c *runManager) setupNetworkPolicyThatIsolatesAllPods(ctx context.Context, 
 	return nil
 }
 
-func (c *runManager) setupNetworkPolicyFromConfig(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupNetworkPolicyFromConfig(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupNetworkPolicyFromConfigStub != nil {
 		return c.testing.setupNetworkPolicyFromConfigStub(ctx, runCtx)
 	}
@@ -341,7 +329,7 @@ func (c *runManager) setupNetworkPolicyFromConfig(ctx context.Context, runCtx *r
 	return c.createResource(ctx, manifestYAMLStr, "networkpolicies", "network policy", expectedGroupKind, runCtx)
 }
 
-func (c *runManager) setupStaticLimitRange(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupStaticLimitRange(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupStaticLimitRangeStub != nil {
 		return c.testing.setupStaticLimitRangeStub(ctx, runCtx)
 	}
@@ -356,7 +344,7 @@ func (c *runManager) setupStaticLimitRange(ctx context.Context, runCtx *runConte
 	return nil
 }
 
-func (c *runManager) setupLimitRangeFromConfig(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupLimitRangeFromConfig(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupLimitRangeFromConfigStub != nil {
 		return c.testing.setupLimitRangeFromConfigStub(ctx, runCtx)
 	}
@@ -374,7 +362,7 @@ func (c *runManager) setupLimitRangeFromConfig(ctx context.Context, runCtx *runC
 	return c.createResource(ctx, configStr, "limitranges", "limit range", expectedGroupKind, runCtx)
 }
 
-func (c *runManager) setupStaticResourceQuota(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupStaticResourceQuota(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupStaticResourceQuotaStub != nil {
 		return c.testing.setupStaticResourceQuotaStub(ctx, runCtx)
 	}
@@ -389,7 +377,7 @@ func (c *runManager) setupStaticResourceQuota(ctx context.Context, runCtx *runCo
 	return nil
 }
 
-func (c *runManager) setupResourceQuotaFromConfig(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) setupResourceQuotaFromConfig(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.setupResourceQuotaFromConfigStub != nil {
 		return c.testing.setupResourceQuotaFromConfigStub(ctx, runCtx)
 	}
@@ -407,7 +395,7 @@ func (c *runManager) setupResourceQuotaFromConfig(ctx context.Context, runCtx *r
 	return c.createResource(ctx, configStr, "resourcequotas", "resource quota", expectedGroupKind, runCtx)
 }
 
-func (c *runManager) createResource(ctx context.Context, configStr string, resource string, resourceDisplayName string, expectedGroupKind schema.GroupKind, runCtx *runContext) error {
+func (c *TektonRunManager) createResource(ctx context.Context, configStr string, resource string, resourceDisplayName string, expectedGroupKind schema.GroupKind, runCtx *runContext) error {
 	var obj *unstructured.Unstructured
 
 	// decode
@@ -462,7 +450,7 @@ func GetPipelineRunKeyAnnotation(object metav1.Object) string {
 	return annotations[annotationPipelineRunKey]
 }
 
-func (c *runManager) createTektonTaskRunObject(ctx context.Context, runCtx *runContext) (*tekton.TaskRun, error) {
+func (c *TektonRunManager) createTektonTaskRunObject(ctx context.Context, runCtx *runContext) (*tekton.TaskRun, error) {
 
 	var err error
 
@@ -478,7 +466,7 @@ func (c *runManager) createTektonTaskRunObject(ctx context.Context, runCtx *runC
 	automount := true
 	tektonTaskRun := tekton.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.TektonTaskRunName,
+			Name:      JFRTaskRunName,
 			Namespace: namespace,
 			Annotations: map[string]string{
 				annotationPipelineRunKey: runCtx.pipelineRun.GetKey(),
@@ -541,7 +529,7 @@ func getTimeout(runCtx *runContext) *metav1.Duration {
 	return timeout
 }
 
-func (c *runManager) createTektonTaskRun(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) createTektonTaskRun(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.createTektonTaskRunStub != nil {
 		return c.testing.createTektonTaskRunStub(ctx, runCtx)
 	}
@@ -555,7 +543,7 @@ func (c *runManager) createTektonTaskRun(ctx context.Context, runCtx *runContext
 	return err
 }
 
-func (c *runManager) addTektonTaskRunParamsForJenkinsfileRunnerImage(
+func (c *TektonRunManager) addTektonTaskRunParamsForJenkinsfileRunnerImage(
 	runCtx *runContext,
 	tektonTaskRun *tekton.TaskRun,
 ) {
@@ -581,7 +569,7 @@ func (c *runManager) addTektonTaskRunParamsForJenkinsfileRunnerImage(
 	tektonTaskRun.Spec.Params = append(tektonTaskRun.Spec.Params, params...)
 }
 
-func (c *runManager) addTektonTaskRunParamsForRunDetails(
+func (c *TektonRunManager) addTektonTaskRunParamsForRunDetails(
 	runCtx *runContext,
 	tektonTaskRun *tekton.TaskRun,
 ) {
@@ -602,7 +590,7 @@ func (c *runManager) addTektonTaskRunParamsForRunDetails(
 	}
 }
 
-func (c *runManager) addTektonTaskRunParamsForPipeline(
+func (c *TektonRunManager) addTektonTaskRunParamsForPipeline(
 	runCtx *runContext,
 	tektonTaskRun *tekton.TaskRun,
 ) error {
@@ -629,7 +617,7 @@ func (c *runManager) addTektonTaskRunParamsForPipeline(
 	return nil
 }
 
-func (c *runManager) addTektonTaskRunParamsForLoggingElasticsearch(
+func (c *TektonRunManager) addTektonTaskRunParamsForLoggingElasticsearch(
 	runCtx *runContext,
 	tektonTaskRun *tekton.TaskRun,
 ) error {
@@ -671,7 +659,7 @@ func (c *runManager) addTektonTaskRunParamsForLoggingElasticsearch(
 	return nil
 }
 
-func (c *runManager) recoverableIfTransient(err error) error {
+func (c *TektonRunManager) recoverableIfTransient(err error) error {
 	return serrors.RecoverableIf(err,
 		k8serrors.IsServerTimeout(err) ||
 			k8serrors.IsServiceUnavailable(err) ||
@@ -681,26 +669,26 @@ func (c *runManager) recoverableIfTransient(err error) error {
 			k8serrors.IsUnexpectedServerError(err))
 }
 
-// GetRun based on a pipelineRun
-func (c *runManager) GetRun(ctx context.Context, pipelineRun k8s.PipelineRun) (runifc.Run, error) {
+// GetRun creates a new TektonRunManager.
+func (c *TektonRunManager) GetRun(ctx context.Context, pipelineRun k8s.PipelineRun) (runifc.Run, error) {
 	namespace := pipelineRun.GetRunNamespace()
-	run, err := c.factory.TektonV1beta1().TaskRuns(namespace).Get(ctx, constants.TektonTaskRunName, metav1.GetOptions{})
+	run, err := c.factory.TektonV1beta1().TaskRuns(namespace).Get(ctx, JFRTaskRunName, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, c.recoverableIfTransient(err)
 	}
-	return NewRun(run), nil
+	return newRun(run), nil
 }
 
-// DeleteRun deletes a JFR task run for a given pipeline run.
-func (c *runManager) DeleteRun(ctx context.Context, pipelineRun k8s.PipelineRun) error {
+// DeleteRun creates a new TektonRunManager.
+func (c *TektonRunManager) DeleteRun(ctx context.Context, pipelineRun k8s.PipelineRun) error {
 	namespace := pipelineRun.GetRunNamespace()
 	if namespace == "" {
 		return fmt.Errorf("cannot delete taskrun, run namespace not set in %q", pipelineRun.GetName())
 	}
-	err := c.factory.TektonV1beta1().TaskRuns(namespace).Delete(ctx, constants.TektonTaskRunName, metav1.DeleteOptions{})
+	err := c.factory.TektonV1beta1().TaskRuns(namespace).Delete(ctx, JFRTaskRunName, metav1.DeleteOptions{})
 
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -711,8 +699,8 @@ func (c *runManager) DeleteRun(ctx context.Context, pipelineRun k8s.PipelineRun)
 	return nil
 }
 
-// Cleanup a run based on a pipelineRun
-func (c *runManager) Cleanup(ctx context.Context, pipelineRun k8s.PipelineRun) error {
+// DeleteEnv creates a new TektonRunManager.
+func (c *TektonRunManager) DeleteEnv(ctx context.Context, pipelineRun k8s.PipelineRun) error {
 	runCtx := &runContext{
 		pipelineRun:  pipelineRun,
 		runNamespace: pipelineRun.GetRunNamespace(),
@@ -721,7 +709,7 @@ func (c *runManager) Cleanup(ctx context.Context, pipelineRun k8s.PipelineRun) e
 	return c.cleanupNamespaces(ctx, runCtx)
 }
 
-func (c *runManager) cleanupNamespaces(ctx context.Context, runCtx *runContext) error {
+func (c *TektonRunManager) cleanupNamespaces(ctx context.Context, runCtx *runContext) error {
 	if c.testing != nil && c.testing.cleanupStub != nil {
 		return c.testing.cleanupStub(ctx, runCtx)
 	}
@@ -760,7 +748,7 @@ func (c *runManager) cleanupNamespaces(ctx context.Context, runCtx *runContext) 
 	return fmt.Errorf("cannot delete all namespaces: %s", strings.Join(msg, ", "))
 }
 
-func (c *runManager) createNamespace(ctx context.Context, runCtx *runContext, purpose, randName string) (string, error) {
+func (c *TektonRunManager) createNamespace(ctx context.Context, runCtx *runContext, purpose, randName string) (string, error) {
 	var err error
 
 	wanted := &corev1api.Namespace{
@@ -801,7 +789,7 @@ func (c *runManager) createNamespace(ctx context.Context, runCtx *runContext, pu
 	return created.GetName(), err
 }
 
-func (c *runManager) deleteNamespace(ctx context.Context, name string, options metav1.DeleteOptions) error {
+func (c *TektonRunManager) deleteNamespace(ctx context.Context, name string, options metav1.DeleteOptions) error {
 	isIgnorable := func(err error) bool {
 		return k8serrors.IsNotFound(err) ||
 			k8serrors.IsGone(err) ||

--- a/pkg/runctl/runmgr/run_manager_test.go
+++ b/pkg/runctl/runmgr/run_manager_test.go
@@ -1271,7 +1271,7 @@ func Test__runManager_addTektonTaskRunParamsForLoggingElasticsearch(t *testing.T
 			spec: &stewardv1alpha1.PipelineSpec{
 				Logging: &stewardv1alpha1.Logging{
 					Elasticsearch: &stewardv1alpha1.Elasticsearch{
-						RunID:    &stewardv1alpha1.CustomJSON{DummyRunID},
+						RunID:    &stewardv1alpha1.CustomJSON{Value: DummyRunID},
 						IndexURL: SampleURL,
 					},
 				},
@@ -1286,7 +1286,7 @@ func Test__runManager_addTektonTaskRunParamsForLoggingElasticsearch(t *testing.T
 			spec: &stewardv1alpha1.PipelineSpec{
 				Logging: &stewardv1alpha1.Logging{
 					Elasticsearch: &stewardv1alpha1.Elasticsearch{
-						RunID: &stewardv1alpha1.CustomJSON{DummyRunID},
+						RunID: &stewardv1alpha1.CustomJSON{Value: DummyRunID},
 					},
 				},
 			},
@@ -1315,7 +1315,7 @@ func Test__runManager_addTektonTaskRunParamsForLoggingElasticsearch(t *testing.T
 			spec: &stewardv1alpha1.PipelineSpec{
 				Logging: &stewardv1alpha1.Logging{
 					Elasticsearch: &stewardv1alpha1.Elasticsearch{
-						RunID:    &stewardv1alpha1.CustomJSON{DummyRunID},
+						RunID:    &stewardv1alpha1.CustomJSON{Value: DummyRunID},
 						IndexURL: "wrongscheme://foo.bar",
 					},
 				},
@@ -2159,7 +2159,7 @@ func Test__runManager_DeleteRun_MissingRunNamespace(t *testing.T) {
 	resultError := examinee.DeleteRun(h.ctx, mockPipelineRun)
 
 	// VERIFY
-	assert.Error(t, resultError, `cannot delete taskrun, runnamespace not set in "foo"`)
+	assert.Error(t, resultError, `cannot delete taskrun, run namespace not set in "foo"`)
 
 	mockPipelineRun.EXPECT().UpdateState(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 }

--- a/pkg/runctl/runmgr/run_test.go
+++ b/pkg/runctl/runmgr/run_test.go
@@ -93,7 +93,7 @@ const (
     status: Unknown
     type: Succeeded
   podName: build-pod-38aa76
-  startTime: 
+  startTime:
   steps:
   - container: step-jenkinsfile-runner
     imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
@@ -355,4 +355,38 @@ func Test__GetMessage(t *testing.T) {
 			assert.Equal(t, test.expectedMessage, result)
 		})
 	}
+}
+
+func Test__IsDeleted__WithReceiverNil(t *testing.T) {
+	// EXERCISE
+	result := (*tektonRun)(nil).IsDeleted()
+
+	// VERIFY
+	assert.Assert(t, result == true)
+}
+
+func Test__IsDeleted__WithoutTerminationTimestamp(t *testing.T) {
+	// SETUP
+	taskRun := fakeTektonTaskRun(emptyBuild)
+	taskRun.DeletionTimestamp = nil
+	run := NewRun(taskRun)
+
+	// EXERCISE
+	result := run.IsDeleted()
+
+	// VERIFY
+	assert.Assert(t, result == false)
+}
+
+func Test__IsDeleted__WithTerminationTimestamp(t *testing.T) {
+	// SETUP
+	taskRun := fakeTektonTaskRun(emptyBuild)
+	taskRun.DeletionTimestamp = &metav1.Time{}
+	run := NewRun(taskRun)
+
+	// EXERCISE
+	result := run.IsDeleted()
+
+	// VERIFY
+	assert.Assert(t, result == true)
 }

--- a/pkg/runctl/runmgr/run_test.go
+++ b/pkg/runctl/runmgr/run_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	api "github.com/SAP/stewardci-core/pkg/apis/steward/v1alpha1"
-	"github.com/ghodss/yaml"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -18,170 +18,291 @@ const (
 	stepStartTime = `2019-05-14T08:24:11Z`
 	emptyBuild    = `{}`
 
-	runningBuild = `{"status":
-	                  {"steps": [
-	                    {"name": "jenkinsfile-runner",
-	                     "running": {"startedAt": "` + stepStartTime + `"}}]}}`
+	runningBuild = `{
+		"status": {
+			"steps": [
+				{
+					"name": "jenkinsfile-runner",
+					"running": {
+						"startedAt": "` + stepStartTime + `"
+					}
+				}
+			]
+		}
+	}`
 
-	completedSuccess = `{"status":
-	                        {"conditions": [
-	                            {"message": "message1",
-	                             "reason": "Succeeded",
-	                             "status": "True",
-	                             "type": "Succeeded"}],
-	                         "steps": [
-	                            {"name": "jenkinsfile-runner",
-	                             "terminated": {
-	                                "reason": "Completed",
-	                                "message": "ok",
-	                                "exitCode": 0}}]}}`
+	completedSuccess = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "message1",
+					"reason": "Succeeded",
+					"status": "True",
+					"type": "Succeeded"
+				}
+			],
+			"steps": [
+				{
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"reason": "Completed",
+						"message": "ok",
+						"exitCode": 0
+					}
+				}
+			]
+		}
+	}`
 
-	completedErrorInfra = `{"status":
-	                           {"conditions": [
-	                               {"message": "message1",
-	                                "reason": "Failed",
-	                                "status": "False",
-	                                "type": "Succeeded"}],
-	                            "steps": [
-	                               {"name": "jenkinsfile-runner",
-	                                "terminated": {
-	                                   "reason": "Error",
-	                                   "message": "ko",
-	                                   "exitCode": 1}}]}}`
+	completedErrorInfra = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "message1",
+					"reason": "Failed",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			],
+			"steps": [
+				{
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"reason": "Error",
+						"message": "ko",
+						"exitCode": 1
+					}
+				}
+			]
+		}
+	}`
 
-	completedErrorContent = `{"status":
-	                            {"conditions": [
-	                                {"message": "message1",
-	                                 "reason": "Failed",
-	                                 "status": "False",
-	                                 "type": "Succeeded"}],
-	                             "steps": [
-	                                {"name": "jenkinsfile-runner",
-	                                 "terminated": {
-	                                    "reason": "Error",
-	                                    "message": "ko",
-	                                    "exitCode": 2}}]}}`
+	completedErrorContent = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "message1",
+					"reason": "Failed",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			],
+			"steps": [
+				{
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"reason": "Error",
+						"message": "ko",
+						"exitCode": 2
+					}
+				}
+			]
+		}
+	}`
 
-	completedErrorConfig = `{"status":
-	                           {"conditions": [
-	                               {"message": "message1",
-	                                "reason": "Failed",
-	                                "status": "False",
-	                                "type": "Succeeded"}],
-	                            "steps": [
-	                               {"name": "jenkinsfile-runner",
-	                                "terminated": {
-	                                   "reason": "Error",
-	                                   "message": "ko",
-	                                   "exitCode": 3}}]}}`
+	completedErrorConfig = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "message1",
+					"reason": "Failed",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			],
+			"steps": [
+				{
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"reason": "Error",
+						"message": "ko",
+						"exitCode": 3
+					}
+				}
+			]
+		}
+	}`
 
-	completedValidationFailed = `{"status":
-	                                {"conditions": [
-	                                    {"message": "message1",
-	                                     "reason": "TaskRunValidationFailed",
-	                                     "status": "False",
-	                                     "type": "Succeeded"}]}}`
+	completedValidationFailed = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "message1",
+					"reason": "TaskRunValidationFailed",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			]
+		}
+	}`
 
 	//See issue https://github.com/SAP/stewardci-core/issues/? TODO: create public issue. internal: 21
-	timeout = `{"status": {"conditions": [{"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"", "reason": "TaskRunTimeout", "status": "False", "type": "Succeeded"}]}}`
+	timeout = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "TaskRun \"steward-jenkinsfile-runner\" failed to finish within \"10m0s\"",
+					"reason": "TaskRunTimeout",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			]
+		}
+	}`
 
-	realStartedBuild = `status:
-  conditions:
-  - lastTransitionTime: ` + taskStartTime + `
-    message: Not all Steps in the Task have finished executing
-    reason: Running
-    status: Unknown
-    type: Succeeded
-  podName: build-pod-38aa76
-  startTime:
-  steps:
-  - container: step-jenkinsfile-runner
-    imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
-    name: jenkinsfile-runner
-    running:
-      startedAt: "` + stepStartTime + `"
-`
+	realStartedBuild = `{
+		"status": {
+			"conditions": [
+				{
+					"lastTransitionTime": "` + taskStartTime + `",
+					"message": "Not all Steps in the Task have finished executing",
+					"reason": "Running",
+					"status": "Unknown",
+					"type": "Succeeded"
+				}
+			],
+			"podName": "build-pod-38aa76",
+			"startTime": null,
+			"steps": [
+				{
+					"container": "step-jenkinsfile-runner",
+					"imageID": "docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f",
+					"name": "jenkinsfile-runner",
+					"running": {
+						"startedAt": "` + stepStartTime + `"
+					}
+				}
+			]
+		}
+	}`
 
-	realCompletedSuccess = `status:
-  completionTime: "2019-05-14T08:24:49Z"
-  conditions:
-  - lastTransitionTime: "2019-10-04T13:57:28Z"
-    message: All Steps have completed executing
-    reason: Succeeded
-    status: "True"
-    type: Succeeded
-  podName: build-pod-38aa76
-  startTime: "2019-05-14T08:24:08Z"
-  steps:
-  - container: step-jenkinsfile-runner
-    imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
-    name: jenkinsfile-runner
-    terminated:
-      containerID: docker://2ee92b9e6971cd76f896c5c4dc403203754bd4aa6c5191541e5f7d8e04ce9326
-      exitCode: 0
-      finishedAt: "2019-05-14T08:24:49Z"
-      reason: Completed
-      startedAt: "2019-05-14T08:24:11Z"
-`
+	realCompletedSuccess = `{
+		"status": {
+			"completionTime": "2019-05-14T08:24:49Z",
+			"conditions": [
+				{
+					"lastTransitionTime": "2019-10-04T13:57:28Z",
+					"message": "All Steps have completed executing",
+					"reason": "Succeeded",
+					"status": "True",
+					"type": "Succeeded"
+				}
+			],
+			"podName": "build-pod-38aa76",
+			"startTime": "2019-05-14T08:24:08Z",
+			"steps": [
+				{
+					"container": "step-jenkinsfile-runner",
+					"imageID": "docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f",
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"containerID": "docker://2ee92b9e6971cd76f896c5c4dc403203754bd4aa6c5191541e5f7d8e04ce9326",
+						"exitCode": 0,
+						"finishedAt": "2019-05-14T08:24:49Z",
+						"reason": "Completed",
+						"startedAt": "2019-05-14T08:24:11Z"
+					}
+				}
+			]
+		}
+	}`
 
-	completedMessageSuccess = `status:
-  completionTime: "2019-05-14T08:24:49Z"
-  conditions:
-  - lastTransitionTime: "2019-10-04T13:57:28Z"
-    message: All Steps have completed executing
-    reason: Succeeded
-    status: "True"
-    type: Succeeded
-  podName: build-pod-38aa76
-  startTime: "2019-05-14T08:24:08Z"
-  steps:
-  - container: step-jenkinsfile-runner
-    imageID: docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f
-    name: jenkinsfile-runner
-    terminated:
-      containerID: docker://2ee92b9e6971cd76f896c5c4dc403203754bd4aa6c5191541e5f7d8e04ce9326
-      exitCode: 0
-      finishedAt: "2019-05-14T08:24:49Z"
-      reason: Completed
-      message: %q
-      startedAt: "2019-05-14T08:24:11Z"
-`
-	completionTimeSet = `status:
-  completionTime: 2019-05-14T08:24:49Z
-  `
-	completionTimeNotSet = `status: {}`
+	completedMessageSuccess = `{
+		"status": {
+			"completionTime": "2019-05-14T08:24:49Z",
+			"conditions": [
+				{
+					"lastTransitionTime": "2019-10-04T13:57:28Z",
+					"message": "All Steps have completed executing",
+					"reason": "Succeeded",
+					"status": "True",
+					"type": "Succeeded"
+				}
+			],
+			"podName": "build-pod-38aa76",
+			"startTime": "2019-05-14T08:24:08Z",
+			"steps": [
+				{
+					"container": "step-jenkinsfile-runner",
+					"imageID": "docker-pullable://alpine@sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f",
+					"name": "jenkinsfile-runner",
+					"terminated": {
+						"containerID": "docker://2ee92b9e6971cd76f896c5c4dc403203754bd4aa6c5191541e5f7d8e04ce9326",
+						"exitCode": 0,
+						"finishedAt": "2019-05-14T08:24:49Z",
+						"reason": "Completed",
+						"message": %q,
+						"startedAt": "2019-05-14T08:24:11Z"
+					}
+				}
+			]
+		}
+	}`
 
-	conditionSuccessWithTransitionTime = `status:
-  conditions:
-  - lastTransitionTime: "2021-10-07T08:59:59Z"
-    message: 'foo'
-    reason: CouldntGetTask
-    status: "False"
-    type: Succeeded
-  `
-	conditionSuccessWithoutTransitionTime = `status:
-  conditions:
-  - message: 'bar'
-    reason: CouldntGetTask
-    status: "False"
-    type: Succeeded
-  `
-	noSuccessCondition = `status:
-  conditions:
-  - lastTransitionTime: "2021-10-07T08:59:59Z"
-    message: 'baz'
-    reason: CouldntGetTask
-    status: "False"
-    type: Foo
-  `
-	imagePullFailedCondition = `status:
-  conditions:
-  - lastTransitionTime: "2022-12-02T12:30:01Z"
-    message: 'failed to pull the image'
-    reason: TaskRunImagePullFailed
-    status: "False"
-    type: Succeeded
-`
+	completionTimeSet = `{
+		"status": {
+			"completionTime": "2019-05-14T08:24:49Z"
+		}
+	}`
+
+	completionTimeNotSet = `{
+		"status": {}
+	}`
+
+	conditionSuccessWithTransitionTime = `{
+		"status": {
+			"conditions": [
+				{
+					"lastTransitionTime": "2021-10-07T08:59:59Z",
+					"message": "foo",
+					"reason": "CouldntGetTask",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			]
+		}
+	}`
+
+	conditionSuccessWithoutTransitionTime = `{
+		"status": {
+			"conditions": [
+				{
+					"message": "bar",
+					"reason": "CouldntGetTask",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			]
+		}
+	}`
+
+	noSuccessCondition = `{
+		"status": {
+			"conditions": [
+				{
+					"lastTransitionTime": "2021-10-07T08:59:59Z",
+					"message": "baz",
+					"reason": "CouldntGetTask",
+					"status": "False",
+					"type": "Foo"
+				}
+			]
+		}
+	}`
+
+	imagePullFailedCondition = `{
+		"status": {
+			"conditions": [
+				{
+					"lastTransitionTime": "2022-12-02T12:30:01Z",
+					"message": "failed to pull the image",
+					"reason": "TaskRunImagePullFailed",
+					"status": "False",
+					"type": "Succeeded"
+				}
+			]
+		}
+	}`
 )
 
 func generateTime(timeRFC3339String string) *metav1.Time {
@@ -190,48 +311,64 @@ func generateTime(timeRFC3339String string) *metav1.Time {
 	return &mt
 }
 
-func fakeTektonTaskRun(s string) *tekton.TaskRun {
+func fakeTektonTaskRunFromJSON(s string) *tekton.TaskRun {
 	var result tekton.TaskRun
-	json.Unmarshal([]byte(s), &result)
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		panic(err)
+	}
 	return &result
 }
 
-func fakeTektonTaskRunYaml(s string) *tekton.TaskRun {
-	var result tekton.TaskRun
-	yaml.Unmarshal([]byte(s), &result)
-	return &result
-}
+func Test__GetStartTime__UnsetReturnsNil(t *testing.T) {
+	// SETUP
+	run := newRun(fakeTektonTaskRunFromJSON(emptyBuild))
 
-func Test__GetStartTime_UnsetReturnsNil(t *testing.T) {
-	run := NewRun(fakeTektonTaskRun(emptyBuild))
+	// EXERCISE
 	startTime := run.GetStartTime()
+
+	// VERIFY
 	assert.Assert(t, startTime == nil)
 }
 
-func Test__GetStartTime_Set(t *testing.T) {
+func Test__GetStartTime__Set(t *testing.T) {
+	// SETUP
 	expectedTime := generateTime(stepStartTime)
-	run := NewRun(fakeTektonTaskRunYaml(realStartedBuild))
+	run := newRun(fakeTektonTaskRunFromJSON(realStartedBuild))
+
+	// EXERCISE
 	startTime := run.GetStartTime()
+
+	// VERIFY
 	assert.Assert(t, expectedTime.Equal(startTime), fmt.Sprintf("Expected: %s, Is: %s", expectedTime, startTime))
 }
 
-func Test__IsFinished_RunningUpdatesContainer(t *testing.T) {
-	run := NewRun(fakeTektonTaskRun(runningBuild))
+func Test__IsFinished__RunningUpdatesContainer(t *testing.T) {
+	// SETUP
+	run := newRun(fakeTektonTaskRunFromJSON(runningBuild))
+
+	// EXERCISE
 	finished, _ := run.IsFinished()
+
+	// VERIFY
 	assert.Assert(t, run.GetContainerInfo().Running != nil)
 	assert.Assert(t, finished == false)
 }
 
-func Test__IsFinished_CompletedSuccess(t *testing.T) {
-	build := fakeTektonTaskRunYaml(realCompletedSuccess)
-	run := NewRun(build)
+func Test__IsFinished__CompletedSuccess(t *testing.T) {
+	// SETUP
+	build := fakeTektonTaskRunFromJSON(realCompletedSuccess)
+	run := newRun(build)
+
+	// EXERCISE
 	finished, result := run.IsFinished()
+
+	// VERIFY
 	assert.Assert(t, run.GetContainerInfo().Terminated != nil)
 	assert.Assert(t, finished == true)
 	assert.Equal(t, result, api.ResultSuccess)
 }
 
-func Test__IsFinished_CompletedFail(t *testing.T) {
+func Test__IsFinished__CompletedFail(t *testing.T) {
 	for _, test := range []struct {
 		name           string
 		trString       string
@@ -252,10 +389,14 @@ func Test__IsFinished_CompletedFail(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			// SETUP
+			build := fakeTektonTaskRunFromJSON(test.trString)
+			run := newRun(build)
 
-			build := fakeTektonTaskRun(test.trString)
-			run := NewRun(build)
+			// EXERCISE
 			finished, result := run.IsFinished()
+
+			// VERIFY
 			assert.Assert(t, run.GetContainerInfo().Terminated != nil)
 			assert.Assert(t, finished == true)
 			assert.Equal(t, result, test.expectedResult)
@@ -263,23 +404,33 @@ func Test__IsFinished_CompletedFail(t *testing.T) {
 	}
 }
 
-func Test__IsFinished_CompletedValidationFail(t *testing.T) {
-	build := fakeTektonTaskRun(completedValidationFailed)
-	run := NewRun(build)
+func Test__IsFinished__CompletedValidationFail(t *testing.T) {
+	// SETUP
+	build := fakeTektonTaskRunFromJSON(completedValidationFailed)
+	run := newRun(build)
+
+	// EXERCISE
 	finished, result := run.IsFinished()
+
+	// VERIFY
 	assert.Assert(t, finished == true)
 	assert.Equal(t, result, api.ResultErrorInfra)
 }
 
-func Test__IsFinished_Timeout(t *testing.T) {
-	run := NewRun(fakeTektonTaskRun(timeout))
+func Test__IsFinished__Timeout(t *testing.T) {
+	// SETUP
+	run := newRun(fakeTektonTaskRunFromJSON(timeout))
+
+	// EXERCISE
 	finished, result := run.IsFinished()
+
+	// VERIFY
 	assert.Assert(t, run.GetContainerInfo() == nil)
 	assert.Assert(t, finished == true)
 	assert.Equal(t, result, api.ResultTimeout)
 }
 
-func Test__IsRestartable_False(t *testing.T) {
+func Test__IsRestartable__False(t *testing.T) {
 	for id, taskrun := range []string{
 		completedSuccess,
 		completedErrorInfra,
@@ -289,16 +440,26 @@ func Test__IsRestartable_False(t *testing.T) {
 		timeout,
 	} {
 		t.Run(fmt.Sprintf("%d", id), func(t *testing.T) {
-			run := NewRun(fakeTektonTaskRun(taskrun))
+			// SETUP
+			run := newRun(fakeTektonTaskRunFromJSON(taskrun))
+
+			// EXERCISE
 			result := run.IsRestartable()
+
+			// VERIFY
 			assert.Assert(t, result == false)
 		})
 	}
 }
 
-func Test__IsRestartable_ImagePullFailed(t *testing.T) {
-	run := NewRun(fakeTektonTaskRunYaml(imagePullFailedCondition))
+func Test__IsRestartable__ImagePullFailed(t *testing.T) {
+	// SETUP
+	run := newRun(fakeTektonTaskRunFromJSON(imagePullFailedCondition))
+
+	// EXERCISE
 	result := run.IsRestartable()
+
+	// VERIFY
 	assert.Assert(t, result)
 }
 
@@ -311,8 +472,13 @@ func Test__GetCompletionTime(t *testing.T) {
 		noSuccessCondition,
 	} {
 		t.Run(fmt.Sprintf("%d", id), func(t *testing.T) {
-			run := NewRun(fakeTektonTaskRunYaml(taskrun))
+			// SETUP
+			run := newRun(fakeTektonTaskRunFromJSON(taskrun))
+
+			// EXERCISE
 			completionTime := run.GetCompletionTime()
+
+			// VERIFY
 			assert.Assert(t, completionTime != nil)
 		})
 	}
@@ -346,12 +512,15 @@ func Test__GetMessage(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			test := test
-			t.Parallel()
+			// SETUP
 			buildString := fmt.Sprintf(completedMessageSuccess, test.inputMessage)
-			build := fakeTektonTaskRunYaml(buildString)
-			run := NewRun(build)
+			build := fakeTektonTaskRunFromJSON(buildString)
+			run := newRun(build)
+
+			// EXERCISE
 			result := run.GetMessage()
+
+			// VERIFY
 			assert.Equal(t, test.expectedMessage, result)
 		})
 	}
@@ -367,9 +536,9 @@ func Test__IsDeleted__WithReceiverNil(t *testing.T) {
 
 func Test__IsDeleted__WithoutTerminationTimestamp(t *testing.T) {
 	// SETUP
-	taskRun := fakeTektonTaskRun(emptyBuild)
+	taskRun := fakeTektonTaskRunFromJSON(emptyBuild)
 	taskRun.DeletionTimestamp = nil
-	run := NewRun(taskRun)
+	run := newRun(taskRun)
 
 	// EXERCISE
 	result := run.IsDeleted()
@@ -380,9 +549,9 @@ func Test__IsDeleted__WithoutTerminationTimestamp(t *testing.T) {
 
 func Test__IsDeleted__WithTerminationTimestamp(t *testing.T) {
 	// SETUP
-	taskRun := fakeTektonTaskRun(emptyBuild)
+	taskRun := fakeTektonTaskRunFromJSON(emptyBuild)
 	taskRun.DeletionTimestamp = &metav1.Time{}
-	run := NewRun(taskRun)
+	run := newRun(taskRun)
 
 	// EXERCISE
 	result := run.IsDeleted()


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->

- Recreate JFR TaskRun if pod creation failed

    The creation of the JFR pod may temporarily fail, e.g. due to a
    timeout calling a mandatory admission webhook. Steward should detect
    this and recreate the Tekton taskrun to retry.

- Stop waiting for finished non-restartable JFR TaskRun

    If a JFR TaskRun was never started, is finished and is not
    restartable, Steward now fails the PipelineRun instead of waiting
    until timeout.

### Submitter checklist

- [x] Change has been tested (on a back-end cluster)
- [x] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [x] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There is at least 1 approval for the pull request and no outstanding requests for change
- [x] All voter checks have passed
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] The Pull Request title is understandable and reflects the changes well
- [x] The Pull Request description is understandable and well documented
- [x] [changelog.yaml] entry for this Pull Request has been added
    - [x] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
